### PR TITLE
Requests made without authenticating are not formed properly

### DIFF
--- a/application/ui/pages/api.jsx
+++ b/application/ui/pages/api.jsx
@@ -60,6 +60,11 @@ module.exports = React.createClass({
                 tokenType   : queryString.token_type,
                 rawData     : queryString
             });
+        } else {
+            this.props.stores.oauth.setOptions({
+                api          : config.api,
+                oauth2       : config.oauth2
+            });
         }
     },
 


### PR DESCRIPTION
setOptions is not called when making a request without first authenticating which results in requests being sent to localhost:80
