### PR TITLE
add strict type support to the api

### DIFF
--- a/application/ui/components/param.jsx
+++ b/application/ui/components/param.jsx
@@ -31,7 +31,7 @@ module.exports = React.createClass({
         var value = this.refs.input.getValue(),
             type  = this.props.type;
 
-        if (type === 'integer') {
+        if (type === 'int' || type = 'integer') {
             return parseInt(value, 10);
         } else if (type === 'bool' || type === 'boolean') {
             return (value === 'true');


### PR DESCRIPTION
## As a USER, I can make requests that send variables as the correct type, so that type-specific endpoints can be tested with lively
### Acceptance Criteria
1. Parameters of type `string` are sent as strings.
2. Parameters of type `integer` are sent as integers.
3. Parameters of type `float` are sent as floats.
4. Parameters of type `boolean` are sent as booleans.
### Tasks
- None
### Additional Notes
- None
