### PR TITLE
Method Naming Conflict in GitHub API Example

### DIFF
--- a/application/config/github/git_data/references.js
+++ b/application/config/github/git_data/references.js
@@ -93,7 +93,7 @@ module.exports = {
                     description : 'The SHA1 value to set this reference to.'
                 },
                 {
-                    name         : 'ref',
+                    name         : 'force',
                     required     : false,
                     defaultValue : false,
                     type         : 'boolean',


### PR DESCRIPTION
## Description

The "References" page in the GitHub example throws this error:

```
Uncaught Error: Invariant Violation: flattenChildren(...): Encountered two children with the same key, `.1:$ref`. Children keys must be unique.
```

It's because there are 2 parameters in the same method (`Update a Reference`) which are both named `ref`.
## Details
- Steps to Reproduce: 
  1. Load the "References" page.
