### PR TITLE
POST requests not done correctly

### DIFF
--- a/application/store/oauth2.js
+++ b/application/store/oauth2.js
@@ -98,7 +98,7 @@ var Store = BaseStore.extend({
 
         return {
             uri     : req.uri,
-            data    : req.body,
+            data    : data,
             headers : req._headers
         };
     },
@@ -128,6 +128,12 @@ var Store = BaseStore.extend({
             'Content-Type' : 'application/json'
         }, data.header);
 
+        // @todo update where we send data.body to request() to make it always a string
+        // then we can remove the JSON.stringify from here and just do data.body.length
+        if (data && data.body) {
+            headers['Content-Length'] = JSON.stringify(data.body).length;
+        }
+
         var urlParts = url.parse(path, true);
         var query    = _.extend({}, urlParts.query, data.query);
 
@@ -146,7 +152,7 @@ var Store = BaseStore.extend({
             headers         : headers
         };
 
-        return this._request(options, data, cb);
+        return this._request(options, data.body, cb);
     },
 
     serializeToLocalStorage : function()


### PR DESCRIPTION
## POST requests not done correctly

When making a `POST` request, instead of applying query, body, and header params in the expected way, they are all passed as JSON data in the body.
