### PR TITLE
Links on Event Types & Payloads section go to api.github.com

### DIFF
--- a/application/config/github/activity/event-types-summary.md
+++ b/application/config/github/activity/event-types-summary.md
@@ -203,7 +203,7 @@ Key | Type | Description
 
 ## IssueCommentEvent
 
-Triggered when an [issue comment](/issues-comments) is created.
+Triggered when an [issue comment](/github/issues-comments) is created.
 
 ### Event name
 
@@ -215,7 +215,7 @@ Key | Type | Description
 ----|------|-------------
 `action`|`string` | The action that was performed on the comment. Currently, can only be "created".
 `issue`|`object` | The [issue](/github/issues) the comment belongs to.
-`comment`|`object` | The [comment](/issues-comments) itself.
+`comment`|`object` | The [comment](/github/issues-comments) itself.
 
 ## IssuesEvent
 


### PR DESCRIPTION
## Description

There are several links on the Event Types & Payloads section that attempt to navigate to api.github.com. These should probably either be updated to go to the relevant section of our lively docs or removed altogether. 

For instance the repository webhooks link attempts to go to https://api.github.com/v3/repos/hooks/, but should probably either go to /github/hooks or not be a link.
## Details

/github/event-types--payloads
