### PR TITLE
Quotes are added around integers in the request body

### DIFF
--- a/application/ui/components/method.jsx
+++ b/application/ui/components/method.jsx
@@ -106,10 +106,6 @@ module.exports = React.createClass({
 
             var paramData = _.findWhere(this.props.params, { name : name });
 
-            if (paramData.type === 'integer') {
-                value = parseInt(value, 10);
-            }
-
             if (paramData.location === 'header') {
                 headerParams[name] = value;
             } else if (paramData.location === 'query' || method === 'GET') {

--- a/application/ui/components/params-list.jsx
+++ b/application/ui/components/params-list.jsx
@@ -36,6 +36,10 @@ module.exports = React.createClass({
                 value = (value === 'true');
             }
 
+            if (type === 'integer') {
+                value = parseInt(value, 10);
+            }
+
             values = NestedPropertyHandler.set(values, path, value);
 
             component.props.updateValues(values);


### PR DESCRIPTION
## Description

For inputs of type integer, lively is adding quotes around the values before adding them to the request body. This causes problems if the API asserts that the value type should be an integer as it receives a string.
