### PR TITLE
Scroll Method to Top When Expanding

### DIFF
--- a/application/ui/components/method.jsx
+++ b/application/ui/components/method.jsx
@@ -53,8 +53,12 @@ module.exports = React.createClass({
     toggleMethodPanel : function()
     {
         this.props.toggleMethodPanel();
-        if(this.props.methodPanelHidden) {
-            window.scrollTo(0, window.scrollY + this.refs.methodPanel.getDOMNode().getBoundingClientRect().top);
+        if (this.props.methodPanelHidden) {
+            var methodPanel    = this.refs.methodPanel.getDOMNode();
+            var methodPanelTop = methodPanel.getBoundingClientRect().top;
+            var scrollLocation = window.scrollY + methodPanelTop;
+
+            window.scrollTo(0, scrollLocation);
         }
     },
 


### PR DESCRIPTION
## When a method is expanded to perform a request, scroll the header bar to the top of the screen, so that the
### Acceptance Criteria
1. When a method is expanded, it is scrolled to the top.
