### PR TITLE
Expand/Collapse All button should be hidden on pages without methods

### DIFF
--- a/application/ui/components/resource.jsx
+++ b/application/ui/components/resource.jsx
@@ -92,6 +92,16 @@ module.exports = React.createClass({
         });
     },
 
+    renderExpandCollapseButton : function() {
+        if (this.props.methods.length > 1) {
+            return (
+                <button className='button__toggle' onClick={this.handleExpandCollapseClick}>
+                    {(this.state.allExpanded) ? ('Collapse All') : ('Expand All')}
+                </button>
+            );
+        }
+    },
+
     render : function()
     {
         var synopsis;
@@ -106,7 +116,7 @@ module.exports = React.createClass({
             <div className='panel'>
                 <div className='panel__synopsis'>
                     <h1>{this.props.name}</h1>
-                    <button className='button__toggle' onClick={this.handleExpandCollapseClick}>{(this.state.allExpanded) ? ('Collapse All') : ('Expand All')}</button>
+                    {this.renderExpandCollapseButton()}
                     {synopsis}
                 </div>
                 {_.map(this.props.methods, this.getMethodComponent)}


### PR DESCRIPTION
Expand/Collapse button is hidden:
- On pages with 1 method
- On pages with 0 methods
