### PR TITLE
Expanded methods should not save state between pages

### DIFF
--- a/application/ui/components/resource.jsx
+++ b/application/ui/components/resource.jsx
@@ -32,6 +32,23 @@ module.exports = React.createClass({
         };
     },
 
+    /**
+     * Rebuilds state when new props are received
+     *
+     * @param  {Object} nextProps The incoming props
+     */
+    componentWillReceiveProps : function(nextProps)
+    {
+        var expanded = nextProps.methods.map(function() {
+            return false;
+        });
+
+        this.setState({
+            expanded    : expanded,
+            allExpanded : false
+        });
+    },
+
     getDefaultProps : function()
     {
         return {


### PR DESCRIPTION
Currently, when you open a method on a page, browse away from it, and then come back, the method is still expanded. This breaks the expectation of pages not saving their state in between loads.
