### PR TITLE
Display GET querystring params in Request URI box

### DIFF
--- a/application/client.js
+++ b/application/client.js
@@ -76,6 +76,10 @@ module.exports = HttpGateway.extend({
 
         config = this.getConfig();
 
+        if (queryParams && ! _(queryParams).isEmpty()) {
+            path = path + '?' + this._toQuery(queryParams);
+        }
+
         uri = (config.secure ? 'https' : 'http') + '://' + config.hostname + path;
 
         data = _.extend({}, queryParams, bodyParams);


### PR DESCRIPTION
## Display GET querystring params in Request URI box

### Acceptance Criteria
1. GET params that are part of the query string (by having `location : 'query'` in the param.) are shown in the Request URI without having to manually specify them in the URI in the lively config. 

### Additional Notes
For example: if there is one parameter `id` that has `location : 'query'` for a GET Branches endpoint, the URI in the lively doc should just point to the endpoint:

`uri      : '/branches',`

The Request URI that lively displays when the request is submitted should show the parameter as part of the query string:

`http://{domain}/branches?id={input}`