### PR TITLE
Version lock synapse-common to 0.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "react-router"                 : "0.7.0",
     "request"                      : "2.39.0",
     "store"                        : "1.3.16",
-    "synapse-common"               : "git://github.com/synapsestudios/synapse-common",
+    "synapse-common"               : "0.2.0",
     "tiny-lr"                      : "0.0.9",
     "underscore"                   : "1.6.0"
   },


### PR DESCRIPTION
## Version lock Lively to 0.2.0 so it doesn't break

### Acceptance Criteria
1. synapse-common is version locked to 0.2.0
1. Request calls work

### Tasks
- Update package.json

### Additional Notes
- Related to synapsestudios/synapse-common#29