### PR TITLE
Add checkboxes to determine whether or not to send parameter

### DIFF
--- a/application/action/request.js
+++ b/application/action/request.js
@@ -49,9 +49,28 @@ module.exports = {
         });
     },
 
-    setRequestBody : function(body)
+    setRequestValues : function(endpointName, values)
     {
-        this.dispatch(constants.SET_REQUEST_BODY, body);
+        this.dispatch(constants.SET_REQUEST_VALUES, {
+            endpointName : endpointName,
+            values       : values
+        });
+    },
+
+    addToExcludedFields : function(endpointName, field)
+    {
+        this.dispatch(constants.REQUEST_ADD_TO_EXCLUDED_FIELDS, {
+            endpointName : endpointName,
+            field        : field
+        });
+    },
+
+    removeFromExcludedFields : function(endpointName, field)
+    {
+        this.dispatch(constants.REQUEST_REMOVE_FROM_EXCLUDED_FIELDS, {
+            endpointName : endpointName,
+            field        : field
+        });
     }
 
 };

--- a/application/action/request.js
+++ b/application/action/request.js
@@ -47,6 +47,11 @@ module.exports = {
             requestInfo : client.getLastRequestInfo(),
             endpointId  : endpointId
         });
+    },
+
+    setRequestBody : function(body)
+    {
+        this.dispatch(constants.SET_REQUEST_BODY, body);
     }
 
 };

--- a/application/constants.js
+++ b/application/constants.js
@@ -1,11 +1,13 @@
 'use strict';
 
 module.exports = {
-    SET_API                  : 'SET_API',
-    SET_TOKEN                : 'SET_TOKEN',
-    OAUTH_SET_CLIENT_OPTIONS : 'OAUTH_SET_CLIENT_OPTIONS',
-    REQUEST                  : 'REQUEST',
-    REQUEST_SUCCESS          : 'REQUEST_SUCCESS',
-    REQUEST_FAILURE          : 'REQUEST_FAILURE',
-    SET_REQUEST_BODY         : 'SET_REQUEST_BODY'
+    SET_API                             : 'SET_API',
+    SET_TOKEN                           : 'SET_TOKEN',
+    OAUTH_SET_CLIENT_OPTIONS            : 'OAUTH_SET_CLIENT_OPTIONS',
+    REQUEST                             : 'REQUEST',
+    REQUEST_SUCCESS                     : 'REQUEST_SUCCESS',
+    REQUEST_FAILURE                     : 'REQUEST_FAILURE',
+    REQUEST_ADD_TO_EXCLUDED_FIELDS      : 'REQUEST_ADD_TO_EXCLUDED_FIELDS',
+    REQUEST_REMOVE_FROM_EXCLUDED_FIELDS : 'REQUEST_REMOVE_FROM_EXCLUDED_FIELDS',
+    SET_REQUEST_VALUES                  : 'SET_REQUEST_VALUES'
 };

--- a/application/constants.js
+++ b/application/constants.js
@@ -6,5 +6,6 @@ module.exports = {
     OAUTH_SET_CLIENT_OPTIONS : 'OAUTH_SET_CLIENT_OPTIONS',
     REQUEST                  : 'REQUEST',
     REQUEST_SUCCESS          : 'REQUEST_SUCCESS',
-    REQUEST_FAILURE          : 'REQUEST_FAILURE'
+    REQUEST_FAILURE          : 'REQUEST_FAILURE',
+    SET_REQUEST_BODY         : 'SET_REQUEST_BODY'
 };

--- a/application/store/request.js
+++ b/application/store/request.js
@@ -9,14 +9,19 @@ module.exports = Fluxxor.createStore({
 
     initialize : function(options)
     {
-        this.state = {};
+        this.state = {
+            excludedFields : {},
+            values         : {}
+        };
 
         this.bindActions(
             constants.SET_API, 'onSetApi',
             constants.REQUEST, 'onRequest',
             constants.REQUEST_SUCCESS, 'onRequestSuccess',
             constants.REQUEST_FAILURE, 'onRequestFailure',
-            constants.SET_REQUEST_BODY, 'onSetRequestBody'
+            constants.SET_REQUEST_VALUES, 'onSetRequestValues',
+            constants.REQUEST_ADD_TO_EXCLUDED_FIELDS, 'onAddToExcludedFields',
+            constants.REQUEST_REMOVE_FROM_EXCLUDED_FIELDS, 'onRemoveFromExcludedFields'
         );
     },
 
@@ -38,8 +43,8 @@ module.exports = Fluxxor.createStore({
 
     onRequest : function(requestInfo)
     {
-        this.state.request            = requestInfo.requestInfo;
-        this.state.request.endpointId = requestInfo.endpointId;
+        this.state.requestInfo            = requestInfo.requestInfo;
+        this.state.requestInfo.endpointId = requestInfo.endpointId;
 
         this.emit('change');
     },
@@ -47,6 +52,7 @@ module.exports = Fluxxor.createStore({
     onRequestSuccess : function(response)
     {
         this.state.response = response;
+        this.state.responseTimestamp = Date.now();
 
         this.emit('change');
     },
@@ -58,9 +64,50 @@ module.exports = Fluxxor.createStore({
         this.emit('change');
     },
 
-    onSetRequestBody : function(requestBody)
+    onSetRequestValues : function(payload)
     {
-        this.state.requestBody = requestBody;
+        var endpointName, values;
+
+        endpointName = payload.endpointName;
+        values       = payload.values;
+
+        if (! this.state.values[endpointName]) {
+            this.state.values[endpointName] = {};
+        }
+
+        this.state.values[endpointName] = values;
+
+        this.emit('change');
+    },
+
+    onAddToExcludedFields : function(payload)
+    {
+        var endpointName, field;
+
+        endpointName = payload.endpointName;
+        field        = payload.field;
+
+        if (! this.state.excludedFields[endpointName]) {
+            this.state.excludedFields[endpointName] = [];
+        }
+
+        this.state.excludedFields[endpointName].push(field);
+
+        this.emit('change');
+    },
+
+    onRemoveFromExcludedFields : function(payload)
+    {
+        var endpointName, field;
+
+        endpointName = payload.endpointName;
+        field        = payload.field;
+
+        if (! this.state.excludedFields[endpointName]) {
+            this.state.excludedFields[endpointName] = [];
+        }
+
+        this.state.excludedFields[endpointName] = _(this.state.excludedFields[endpointName]).without(field);
 
         this.emit('change');
     }

--- a/application/store/request.js
+++ b/application/store/request.js
@@ -15,7 +15,8 @@ module.exports = Fluxxor.createStore({
             constants.SET_API, 'onSetApi',
             constants.REQUEST, 'onRequest',
             constants.REQUEST_SUCCESS, 'onRequestSuccess',
-            constants.REQUEST_FAILURE, 'onRequestFailure'
+            constants.REQUEST_FAILURE, 'onRequestFailure',
+            constants.SET_REQUEST_BODY, 'onSetRequestBody'
         );
     },
 
@@ -55,5 +56,13 @@ module.exports = Fluxxor.createStore({
         this.state.response = false;
 
         this.emit('change');
+    },
+
+    onSetRequestBody : function(requestBody)
+    {
+        this.state.requestBody = requestBody;
+
+        this.emit('change');
     }
+
 });

--- a/application/ui/components/input/text.jsx
+++ b/application/ui/components/input/text.jsx
@@ -8,7 +8,10 @@ module.exports = React.createClass({
     displayName : 'TextInput',
 
     propTypes : {
-        value    : React.PropTypes.string,
+        value    : React.PropTypes.oneOfType([
+            React.PropTypes.string,
+            React.PropTypes.number
+        ]),
         onChange : React.PropTypes.func
     },
 

--- a/application/ui/components/method.jsx
+++ b/application/ui/components/method.jsx
@@ -132,9 +132,8 @@ module.exports = React.createClass({
 
         _.each(params, _.bind(function(value, name)
         {
-            if (value === '' || _(value).isNaN() || value === null) {
-                // skip empty params
-                return;
+            if (_(value).isNaN() || value === null) {
+                value = '';
             }
 
             var regex = new RegExp(':' + name);

--- a/application/ui/components/method.jsx
+++ b/application/ui/components/method.jsx
@@ -11,7 +11,6 @@ var Params          = require('./params-list');
 var ApiCallInfo     = require('./api-call-info');
 var Checkbox        = require('./input/checkbox');
 var Resumable       = require('../../../bower_components/resumablejs/resumable');
-var ParamHelper     = require('../../util/param-helper');
 
 var LOADED  = 'loaded',
     LOADING = 'loading',
@@ -44,7 +43,6 @@ module.exports = React.createClass({
     getInitialState : function()
     {
         return {
-            requestBody       : ParamHelper.getDefaultValuesForParams(this.props.params),
             methodPanelHidden : true
         };
     },
@@ -275,13 +273,6 @@ module.exports = React.createClass({
         }
     },
 
-    handleUpdatedRequestBody : function(newRequestBody)
-    {
-        this.setState({
-            requestBody : newRequestBody
-        });
-    },
-
     render : function()
     {
         var apiCallInfo;
@@ -331,9 +322,7 @@ module.exports = React.createClass({
                     <div className='panel__synopsis' dangerouslySetInnerHTML={{__html: this.props.synopsis}} />
                     <Params
                         params                  = {this.props.params}
-                        requestBody             = {this.state.requestBody}
                         resumableUploadCallback = {this.initResumableUpload}
-                        updateValues            = {this.handleUpdatedRequestBody}
                         ref                     = 'params'
                     />
                     <div className='switch__container'>

--- a/application/ui/components/method.jsx
+++ b/application/ui/components/method.jsx
@@ -147,7 +147,7 @@ module.exports = React.createClass({
                 return;
             }
 
-            value = (values && values[name]) ?
+            value = (values && _(values).has(name)) ?
                 values[name] :
                 ParamHelper.getDefaultValueForParam(param);
 

--- a/application/ui/components/params-list.jsx
+++ b/application/ui/components/params-list.jsx
@@ -83,9 +83,7 @@ module.exports = React.createClass({
 
     includeChanged : function(event)
     {
-        var values, path, requestActions;
-
-        values = _.extend({}, this.props.requestValues);
+        var path, requestActions;
 
         path = event.currentTarget.dataset.path;
 

--- a/application/util/param-helper.js
+++ b/application/util/param-helper.js
@@ -43,7 +43,7 @@ module.exports = {
         } else if (param.type === 'boolean') {
             return true;
         } else if (param.type === 'enum') {
-            return _.first(param.enumValues)
+            return _.first(param.enumValues);
         } else if (param.type === 'hash') {
             if (! _.isArray(param.params)) {
                 var message = 'Hash type parameter with no sub-parameters defined: ';


### PR DESCRIPTION
## As a Lively user I can choose which parameters to send, so that the parameter is only sent if the checkbox is checked. This allows me to send blank values or leave out required values to test APIs. 

### Acceptance Criteria
1. Each parameter should have a checkbox to determine if it should be sent
2. Each parameter should have an initially blank default value in the form
3. Request logic should be updated to allow sending of blank values

### Additional Notes

Booleans and enums will need a "blank" option.