### PR TITLE
Add support for simple, non-resumable upload

### DIFF
--- a/application/ui/components/method.jsx
+++ b/application/ui/components/method.jsx
@@ -1,5 +1,5 @@
 /** @jsx React.DOM */
-/* global window */
+/* global window, FileReader */
 'use strict';
 
 var _               = require('underscore');
@@ -148,7 +148,9 @@ module.exports = React.createClass({
 
             var paramData = _.findWhere(this.props.params, { name : name });
 
-            if (paramData.location === 'header') {
+            if (paramData.type === 'file') {
+                bodyParams = value;
+            } else if (paramData.location === 'header') {
                 headerParams[name] = value;
             } else if (paramData.location === 'query' || method === 'GET') {
                 queryParams[name] = value;

--- a/application/ui/components/params-list.jsx
+++ b/application/ui/components/params-list.jsx
@@ -33,6 +33,10 @@ module.exports = React.createClass({
 
         return function(value)
         {
+            if (type === 'file') {
+                value = value.currentTarget.files.item(0);
+            }
+
             if (type === 'boolean') {
                 value = (value === 'true');
             }
@@ -228,6 +232,8 @@ module.exports = React.createClass({
             return <Select value={value} key={key} options={['true', 'false']} onChange={changeHandler} />;
         } else if (type === 'resumable-upload') {
             return <ResumableUpload key={key} target={options.uri} resumableUploadCallback={options.resumableUploadCallback} />;
+        } else if (type === 'file') {
+            return <input type='file' key={key} onChange={changeHandler}/>;
         } else if (type === 'hash') {
             return null;
         } else {


### PR DESCRIPTION
## Add support for simple, non-resumable upload

### Acceptance Criteria
1. Can specify param with type "file" and it will appear as an upload field.
1. Upload endpoints work.

### Tasks
- {{list developer tasks here}}

### Additional Notes
- {{list additional notes here, remove if not applicable}}