### PR TITLE
Uncaught TypeError when submitting a request with a querystring parameter

### DIFF
--- a/application/client.js
+++ b/application/client.js
@@ -78,7 +78,7 @@ module.exports = HttpGateway.extend({
         config = this.getConfig();
 
         if (queryParams && ! _(queryParams).isEmpty()) {
-            path = path + '?' + this._toQuery(queryParams);
+            path = path + '?' + this.toQuery(queryParams);
         }
 
         uri = (config.secure ? 'https' : 'http') + '://' + config.hostname + path;
@@ -123,7 +123,7 @@ module.exports = HttpGateway.extend({
         _.extend(options.headers, headers);
 
         if (queryParams && ! _(queryParams).isEmpty()) {
-            options.path = path + '?' + this._toQuery(queryParams);
+            options.path = path + '?' + this.toQuery(queryParams);
         }
 
         if (_.isUndefined(headers)) {


### PR DESCRIPTION
## Description
Uncaught TypeError in console when submitting a request with a querystring parameter.

This started after the upgrade to synapse-common 1.0. re https://github.com/synapsestudios/lively/pull/110

## Details
``` 
 Uncaught TypeError: undefined is not a functionclient.js:127 module.exports.HttpGateway.extend.apiRequestclient.js:34 module.exports.HttpGateway.extend.requestrequest.js:43 module.exports.requestmethod.jsx:188 module.exports.React.createClass.onSubmitReactCompositeComponent.js:1288 boundMethodEventPluginUtils.js:118 executeDispatchSimpleEventPlugin.js:310 SimpleEventPlugin.executeDispatchEventPluginUtils.js:106 forEachEventDispatchEventPluginUtils.js:127 executeDispatchesInOrderEventPluginHub.js:56 executeDispatchesAndReleaseforEachAccumulated.js:32 forEachAccumulatedEventPluginHub.js:270 EventPluginHub.processEventQueueReactEventEmitterMixin.js:25 runEventQueueInBatchReactEventEmitterMixin.js:51 ReactEventEmitterMixin.handleTopLevelReactEventListener.js:87 handleTopLevelImplTransaction.js:142 Mixin.performReactDefaultBatchingStrategy.js:70 ReactDefaultBatchingStrategy.batchedUpdatesReactUpdates.js:114 batchedUpdatesReactEventListener.js:182 ReactEventListener.dispatchEvent
```