### PR TITLE
OAuth "Log Out" Button

### DIFF
--- a/application/ui/components/oauth.jsx
+++ b/application/ui/components/oauth.jsx
@@ -38,7 +38,7 @@ module.exports = React.createClass({
      * Forward browser to the OAuth2 server in the API config, which will redirect the user back
      * with an authorization code for it to use to request the access token
      */
-    handleClick : function()
+    handleConnectClick : function()
     {
         var options = {
             clientId     : this.state.clientId,
@@ -73,6 +73,11 @@ module.exports = React.createClass({
         });
 
         window.location = redirectUrl;
+    },
+
+    handleLogoutClick : function()
+    {
+        this.getFlux().actions.oauth.setToken({});
     },
 
     getInitialState : function()
@@ -146,7 +151,8 @@ module.exports = React.createClass({
                             />
                         </div>
                         <div className='small-12 columns'>
-                            <a className='button right' onClick={this.handleClick}>Connect</a>
+                            <a className='button right' onClick={this.handleLogoutClick}>Log Out</a>
+                            <a className='button right' onClick={this.handleConnectClick}>Connect</a>
                         </div>
                         <hr />
                         <div className='small-6 columns'>


### PR DESCRIPTION
## As a USER, I can click a button and "log out" from OAuth, so that my requests aren't performed with the previously stored OAuth token.

### Acceptance Criteria
1. Button exists
1. When user clicks it, token is removed from localstorage.
1. Padlock icon updates to show user isn't "logged in"

### Tasks
- Add button
- Possibly add functionality to oauth store.

### Additional Notes
- None
