### PR TITLE
NaN displayed when deleting entry or adding non-numeric value to integer type field

### DIFF
--- a/application/ui/components/params-list.jsx
+++ b/application/ui/components/params-list.jsx
@@ -66,7 +66,13 @@ module.exports = React.createClass({
             }
 
             if (type === 'integer') {
-                value = parseInt(value, 10);
+                // ensure we can allow negative numbers
+                if (value != '-') {
+                    value = parseInt(value, 10);
+                    if (isNaN(value)) {
+                        value = '';
+                    }
+                }
             }
 
             values = NestedPropertyHandler.set(values, path, value);


### PR DESCRIPTION
## Description

NaN is displayed when user deletes entry or tries to add non-numeric input to an integer type field.

## Acceptance Criteria

1. Lively does not allow non-numeric values in integer fields

## Details

URL:  