### PR TITLE
Default values aren't populated after logging in via Oauth or navigating to other sections

### DIFF
--- a/application/ui/components/params-list.jsx
+++ b/application/ui/components/params-list.jsx
@@ -42,7 +42,7 @@ module.exports = React.createClass({
         };
     },
 
-    componentWillMount : function()
+    componentDidMount : function()
     {
         this.getFlux().actions.request.setRequestValues(
             this.props.methodName,


### PR DESCRIPTION
## Description
Default values on inputs are forgotten after using the Oauth login or navigating around the site.

Text inputs with default values will be blank and enums will default to the first item in the list, regardless of which defaultValue is specified in the lively doc.
