### PR TITLE
Can't POST payload with child in array[hash] when defaultValue is set

### DIFF
--- a/application/util/param-helper.js
+++ b/application/util/param-helper.js
@@ -44,6 +44,8 @@ module.exports = {
             return param.defaultValue;
         } else if (this.isArrayParam(param.type)) {
             return [];
+        } else if (param.type === 'string') {
+            return '';
         } else if (param.type === 'boolean') {
             return _(param.defaultValue).isUndefined() ? true : param.defaultValue;
         } else if (param.type === 'enum') {

--- a/application/util/param-helper.js
+++ b/application/util/param-helper.js
@@ -36,6 +36,10 @@ module.exports = {
 
     getDefaultValueForParam : function(param)
     {
+        // array[hash] defaults are provided by their sub-params
+        if (param.type == 'array[hash]' && param.hasOwnProperty('defaultValue')) {
+            delete param.defaultValue;
+        }
         if (param.hasOwnProperty('defaultValue')) {
             return param.defaultValue;
         } else if (this.isArrayParam(param.type)) {


### PR DESCRIPTION
## Description

When adding a child record to a configured array[hash] param for POST when a defaultValue is also provided, lively does nothing and eats the exception.

## Acceptance Criteria
1. If a defaultValue is set for an array[hash] property, adding in lively should still properly populate default values of child parameters.

## Details

## Tasks
1. Lively should ignore defaultValue for these types of fields as sub-fields will define their own defaults.