### PR TITLE
Update lively config files to match Github API

### DIFF
--- a/application/config/github/activity.js
+++ b/application/config/github/activity.js
@@ -4,7 +4,7 @@ module.exports = {
     name      : 'Activity',
     slug      : 'activity',
     synopsis  : 'This is a read-only API to the GitHub events.',
-    endpoints   : [],
+    endpoints : [],
     resources : [
         require('./activity/events'),
         require('./activity/feeds'),

--- a/application/config/github/activity.js
+++ b/application/config/github/activity.js
@@ -4,7 +4,7 @@ module.exports = {
     name      : 'Activity',
     slug      : 'activity',
     synopsis  : 'This is a read-only API to the GitHub events.',
-    methods   : [],
+    endpoints   : [],
     resources : [
         require('./activity/events'),
         require('./activity/feeds'),

--- a/application/config/github/activity/event-types-summary.md
+++ b/application/config/github/activity/event-types-summary.md
@@ -1,9 +1,9 @@
 Each event has a similar JSON schema, but a unique `payload` object that is
 determined by its event type.
 
-Event names are used by [repository webhooks](/github/hooks) to specify
+Event names are used by [repository webhooks](../repositories/hooks) to specify
 which events the webhook should receive. The included payloads below are from webhook deliveries but
-match events returned by the [Events API](/github/activity-events) (except where noted).
+match events returned by the [Events API](./events) (except where noted).
 
 
 Note that some of these events may not be rendered in timelines.
@@ -11,7 +11,7 @@ They're only created for various internal and repository hooks.
 
 ## CommitCommentEvent
 
-Triggered when a [commit comment](/github/repo-comments) is created.
+Triggered when a [commit comment](../repositories/comments) is created.
 
 ### Event name
 
@@ -21,7 +21,7 @@ Triggered when a [commit comment](/github/repo-comments) is created.
 
 Key | Type | Description
 ----|------|-------------
-`comment`|`object` | The [comment](/github/repo-comments) itself.
+`comment`|`object` | The [comment](../repositories/comments) itself.
 
 ## CreateEvent
 
@@ -44,7 +44,7 @@ Key | Type | Description
 
 ## DeleteEvent
 
-Represents a [deleted branch or tag](/github/references).
+Represents a [deleted branch or tag](../git_data/references).
 
 ### Event name
 
@@ -116,7 +116,7 @@ Key | Type | Description
 
 ## FollowEvent
 
-Triggered when a user [follows another user](/github/followers).
+Triggered when a user [follows another user](../users/followers).
 
 Events of this type are **no longer created**, but it's possible that they exist in timelines of some users.
 
@@ -128,12 +128,12 @@ Events of this type are **no longer created**, but it's possible that they exist
 
 Key | Type | Description
 ----|------|-------------
-`target`|`object` | The [user](/github/users) that was just followed.
+`target`|`object` | The [user](../users) that was just followed.
 
 
 ## ForkEvent
 
-Triggered when a user [forks a repository](/github/forks).
+Triggered when a user [forks a repository](../repositories/forks).
 
 ### Event name
 
@@ -143,7 +143,7 @@ Triggered when a user [forks a repository](/github/forks).
 
 Key | Type | Description
 ----|------|-------------
-`forkee`|`object` | The created [repository](/github/repositories).
+`forkee`|`object` | The created [repository](../repositories).
 
 ## ForkApplyEvent
 
@@ -166,7 +166,7 @@ Key | Type | Description
 
 ## GistEvent
 
-Triggered when a [Gist](/github/gists) is created or updated.
+Triggered when a [Gist](../gists) is created or updated.
 
 Events of this type are **no longer created**, but it's possible that they exist in timelines of some users.
 
@@ -179,7 +179,7 @@ Events of this type are **no longer created**, but it's possible that they exist
 Key | Type | Description
 ----|------|-------------
 `action`|`string` | The action that was performed. Can be "create" or "update"
-`gist`|`object` | The [gist](/github/gists) itself.
+`gist`|`object` | The [gist](../gists) itself.
 
 
 ## GollumEvent
@@ -203,7 +203,7 @@ Key | Type | Description
 
 ## IssueCommentEvent
 
-Triggered when an [issue comment](/github/issues-comments) is created.
+Triggered when an [issue comment](../issues/comments) is created.
 
 ### Event name
 
@@ -214,12 +214,12 @@ Triggered when an [issue comment](/github/issues-comments) is created.
 Key | Type | Description
 ----|------|-------------
 `action`|`string` | The action that was performed on the comment. Currently, can only be "created".
-`issue`|`object` | The [issue](/github/issues) the comment belongs to.
-`comment`|`object` | The [comment](/github/issues-comments) itself.
+`issue`|`object` | The [issue](../issues) the comment belongs to.
+`comment`|`object` | The [comment](../issues/comments) itself.
 
 ## IssuesEvent
 
-Triggered when an [issue](/github/issues) is created, closed or reopened.
+Triggered when an [issue](../issues) is created, closed or reopened.
 
 ### Event name
 
@@ -230,11 +230,11 @@ Triggered when an [issue](/github/issues) is created, closed or reopened.
 Key | Type | Description
 ----|------|-------------
 `action`|`string` | The action that was performed. Can be one of "opened", "closed", or "reopened".
-`issue`|`object` | The [issue](/github/issues) itself.
+`issue`|`object` | The [issue](../issues) itself.
 
 ## MemberEvent
 
-Triggered when a user is [added as a collaborator](/github/collaborators) to a repository.
+Triggered when a user is [added as a collaborator](../collaborators) to a repository.
 
 ### Event name
 
@@ -244,7 +244,7 @@ Triggered when a user is [added as a collaborator](/github/collaborators) to a r
 
 Key | Type | Description
 ----|------|-------------
-`member`|`object` | The [user](/github/users) that was added.
+`member`|`object` | The [user](../users) that was added.
 `action`|`string` | The action that was performed. Currently, can only be "added".
 
 ## PageBuildEvent
@@ -263,11 +263,11 @@ Events of this type are not visible in timelines, they are only used to trigger 
 
 Key | Type | Description
 ----|------|------------
-`build` | `object` | The [page build](/github/pages) itself.
+`build` | `object` | The [page build](../pages) itself.
 
 ## PublicEvent
 
-Triggered when a private repository is [open sourced](/github/repositories).  Without a doubt: the best GitHub event.
+Triggered when a private repository is [open sourced](../repositories).  Without a doubt: the best GitHub event.
 
 ### Event name
 
@@ -277,7 +277,7 @@ Triggered when a private repository is [open sourced](/github/repositories).  Wi
 
 ## PullRequestEvent
 
-Triggered when a [pull request](/github/pull-requests) is created, closed, reopened or synchronized.
+Triggered when a [pull request](../pull-requests) is created, closed, reopened or synchronized.
 
 ### Event name
 
@@ -289,11 +289,11 @@ Key | Type | Description
 ----|------|-------------
 `action`|`string` | The action that was performed. Can be one of "opened", "closed", "synchronize", or "reopened".
 `number`|`integer` | The pull request number.
-`pull_request`|`object` | The [pull request](/github/pull-requests) itself.
+`pull_request`|`object` | The [pull request](../pull-requests) itself.
 
 ## PullRequestReviewCommentEvent
 
-Triggered when a [comment is created on a portion of the unified diff](/github/review-comments) of a pull request.
+Triggered when a [comment is created on a portion of the unified diff](../pull-requests/review-comments) of a pull request.
 
 ### Event name
 
@@ -304,8 +304,8 @@ Triggered when a [comment is created on a portion of the unified diff](/github/r
 Key | Type | Description
 ----|------|-------------
 `action`|`string` | The action that was performed on the comment. Currently, can only be "created".
-`pull_request`|`object` | The [pull request](/github/pull-requests) the comment belongs to.
-`comment`|`object` | The [comment](/github/review-comments) itself.
+`pull_request`|`object` | The [pull request](../pull-requests) the comment belongs to.
+`comment`|`object` | The [comment](../pull-requests/review-comments) itself.
 
 ## PushEvent
 
@@ -324,7 +324,7 @@ Key | Type | Description
 `head`|`string` | The SHA of the HEAD commit on the repository.
 `ref`|`string` | The full Git ref that was pushed.  Example: "refs/heads/master"
 `size`|`integer` | The number of commits in the push.
-`commits`|`array` | An array of commit objects describing the pushed commits. (The array includes a maximum of 20 commits. If necessary, you can use the [Commits API](/github/repo-commits) to fetch additional commits.)
+`commits`|`array` | An array of commit objects describing the pushed commits. (The array includes a maximum of 20 commits. If necessary, you can use the [Commits API](../repositories/commits) to fetch additional commits.)
 `commits[][sha]`|`string` | The SHA of the commit.
 `commits[][message]`|`string` | The commit message.
 `commits[][author]`|`object` | The git author of the commit.
@@ -335,7 +335,7 @@ Key | Type | Description
 
 ## ReleaseEvent
 
-Triggered when a [release](/github/releases) is published.
+Triggered when a [release](../repositories/releases) is published.
 
 ### Event name
 
@@ -346,7 +346,7 @@ Triggered when a [release](/github/releases) is published.
 Key | Type | Description
 ----|------|-------------
 `action`|`string` | The action that was performed. Currently, can only be "published".
-`release`|`object` | The [release](/github/releases) itself.
+`release`|`object` | The [release](../repositories/releases) itself.
 
 ## StatusEvent
 
@@ -370,9 +370,9 @@ Key | Type | Description
 
 ## TeamAddEvent
 
-Triggered when a [user is added to a team](/github/teams) or when a [repository is added to a team](/github/teams).
+Triggered when a [user is added to a team](../organizations/teams) or when a [repository is added to a team](../organizations/teams).
 
-Note: this event is created in [users' organization timelines](/github/activity-events).
+Note: this event is created in [users' organization timelines](./events).
 
 ### Event name
 
@@ -382,17 +382,17 @@ Note: this event is created in [users' organization timelines](/github/activity-
 
 Key | Type | Description
 ----|------|-------------
-`team`|`object` | The [team](/github/teams) that was modified.  Note: older events may not include this in the payload.
-`user`|`object` | The [user](/github/users) that was added to this team.
-`repository`|`object` | The [repository](/github/repositories) that was added to this team.
+`team`|`object` | The [team](../organizations/teams) that was modified.  Note: older events may not include this in the payload.
+`user`|`object` | The [user](../users) that was added to this team.
+`repository`|`object` | The [repository](../repositories) that was added to this team.
 
 ## WatchEvent
 
-The WatchEvent is related to [starring a repository](/github/starring), not [watching](/github/watching).
+The WatchEvent is related to [starring a repository](./starring), not [watching](./watching).
 See [this API blog post](https://developer.github.com/changes/2012-9-5-watcher-api/) for an explanation.
 
-The event’s actor is the [user](/github/users) who starred a repository, and the
-event’s repository is the [repository](/github/repositories) that was starred.
+The event’s actor is the [user](../users) who starred a repository, and the
+event’s repository is the [repository](../repositories) that was starred.
 
 ### Event name
 

--- a/application/config/github/activity/event_types.js
+++ b/application/config/github/activity/event_types.js
@@ -8,5 +8,5 @@ module.exports = {
     name     : 'Event Types & Payloads',
     slug     : 'event-types',
     synopsis : marked(eventTypesSummary),
-    methods  : []
+    endpoints  : []
 };

--- a/application/config/github/activity/event_types.js
+++ b/application/config/github/activity/event_types.js
@@ -5,8 +5,8 @@ var marked           = require('marked');
 var eventTypesSummary = fs.readFileSync(__dirname + '/event-types-summary.md').toString();
 
 module.exports = {
-    name     : 'Event Types & Payloads',
-    slug     : 'event-types',
-    synopsis : marked(eventTypesSummary),
-    endpoints  : []
+    name      : 'Event Types & Payloads',
+    slug      : 'event-types',
+    synopsis  : marked(eventTypesSummary),
+    endpoints : []
 };

--- a/application/config/github/activity/events.js
+++ b/application/config/github/activity/events.js
@@ -33,8 +33,8 @@ var paramUsername = {
 };
 
 module.exports = {
-    name     : 'Events',
-    synopsis : 'This is a read-only API to the GitHub events. These events power the various activity streams on the site.',
+    name      : 'Events',
+    synopsis  : 'This is a read-only API to the GitHub events. These events power the various activity streams on the site.',
     endpoints : [
         {
             name     : 'List public events',

--- a/application/config/github/activity/events.js
+++ b/application/config/github/activity/events.js
@@ -35,7 +35,7 @@ var paramUsername = {
 module.exports = {
     name     : 'Events',
     synopsis : 'This is a read-only API to the GitHub events. These events power the various activity streams on the site.',
-    methods : [
+    endpoints : [
         {
             name     : 'List public events',
             synopsis : '',

--- a/application/config/github/activity/feeds.js
+++ b/application/config/github/activity/feeds.js
@@ -6,7 +6,7 @@ var listFeedsSummary = fs.readFileSync(__dirname + '/list-feeds-summary.md').toS
 
 module.exports = {
     name     : 'Feeds',
-    methods : [
+    endpoints : [
         {
             name     : 'List feeds',
             synopsis : marked(listFeedsSummary),

--- a/application/config/github/activity/feeds.js
+++ b/application/config/github/activity/feeds.js
@@ -5,7 +5,7 @@ var marked           = require('marked');
 var listFeedsSummary = fs.readFileSync(__dirname + '/list-feeds-summary.md').toString();
 
 module.exports = {
-    name     : 'Feeds',
+    name      : 'Feeds',
     endpoints : [
         {
             name     : 'List feeds',

--- a/application/config/github/activity/notifications.js
+++ b/application/config/github/activity/notifications.js
@@ -109,7 +109,8 @@ module.exports = {
             oauth    : true,
             params   : [
                 paramOwner,
-                paramRepo
+                paramRepo,
+                paramLastReadAt
             ]
         },
         {

--- a/application/config/github/activity/notifications.js
+++ b/application/config/github/activity/notifications.js
@@ -63,7 +63,7 @@ var paramLastReadAt = {
 };
 
 module.exports = {
-    name     : 'Notifications',
+    name      : 'Notifications',
     endpoints : [
         {
             name     : 'List your notifications',

--- a/application/config/github/activity/notifications.js
+++ b/application/config/github/activity/notifications.js
@@ -64,7 +64,7 @@ var paramLastReadAt = {
 
 module.exports = {
     name     : 'Notifications',
-    methods : [
+    endpoints : [
         {
             name     : 'List your notifications',
             synopsis : 'List all notifications for the current user, grouped by repository.',

--- a/application/config/github/activity/starring.js
+++ b/application/config/github/activity/starring.js
@@ -51,7 +51,7 @@ var paramDirection = {
 };
 
 module.exports = {
-    name     : 'Starring',
+    name      : 'Starring',
     endpoints : [
         {
             name     : 'List Stargazers',

--- a/application/config/github/activity/starring.js
+++ b/application/config/github/activity/starring.js
@@ -52,7 +52,7 @@ var paramDirection = {
 
 module.exports = {
     name     : 'Starring',
-    methods : [
+    endpoints : [
         {
             name     : 'List Stargazers',
             synopsis : '',

--- a/application/config/github/activity/watching.js
+++ b/application/config/github/activity/watching.js
@@ -26,7 +26,7 @@ var paramUsername = {
 
 module.exports = {
     name     : 'Watching',
-    methods : [
+    endpoints : [
         {
             name     : 'List Watchers',
             synopsis : '',

--- a/application/config/github/activity/watching.js
+++ b/application/config/github/activity/watching.js
@@ -25,7 +25,7 @@ var paramUsername = {
 };
 
 module.exports = {
-    name     : 'Watching',
+    name      : 'Watching',
     endpoints : [
         {
             name     : 'List Watchers',

--- a/application/config/github/gists.js
+++ b/application/config/github/gists.js
@@ -33,8 +33,8 @@ var paramSHA = {
 };
 
 module.exports = {
-    name     : 'Gists',
-    synopsis : 'You can read public gists and create them for anonymous users without a token; however, to read or write gists on a user’s behalf the **gist** OAuth scope is required.',
+    name      : 'Gists',
+    synopsis  : 'You can read public gists and create them for anonymous users without a token; however, to read or write gists on a user’s behalf the **gist** OAuth scope is required.',
     endpoints : [
         {
             name     : 'List gists',

--- a/application/config/github/gists.js
+++ b/application/config/github/gists.js
@@ -24,6 +24,14 @@ var paramId = {
     description : 'The ID of the gist.'
 };
 
+var paramSHA = {
+    name        : 'sha',
+    required    : true,
+    type        : 'string',
+    location    : 'uri',
+    description : 'The SHA for the specific revision of the gist.'
+};
+
 module.exports = {
     name     : 'Gists',
     synopsis : 'You can read public gists and create them for anonymous users without a token; however, to read or write gists on a user’s behalf the **gist** OAuth scope is required.',
@@ -77,6 +85,17 @@ module.exports = {
             oauth    : false,
             params   : [
                 paramId
+            ]
+        },
+        {
+            name     : 'Get a specific revision of a gist',
+            synopsis : '',
+            method   : 'GET',
+            uri      : '/gists/:id/:sha',
+            oauth    : false,
+            params   : [
+                paramId,
+                paramSHA
             ]
         },
         {

--- a/application/config/github/gists.js
+++ b/application/config/github/gists.js
@@ -35,7 +35,7 @@ var paramSHA = {
 module.exports = {
     name     : 'Gists',
     synopsis : 'You can read public gists and create them for anonymous users without a token; however, to read or write gists on a user’s behalf the **gist** OAuth scope is required.',
-    methods : [
+    endpoints : [
         {
             name     : 'List gists',
             synopsis : 'List the authenticated user’s gists or if called anonymously, this will return all public gists',

--- a/application/config/github/gists/comments.js
+++ b/application/config/github/gists/comments.js
@@ -18,7 +18,7 @@ var paramId = {
 
 module.exports = {
     name     : 'Comments',
-    methods : [
+    endpoints : [
         {
             name     : 'List comments on a gist',
             synopsis : '',

--- a/application/config/github/gists/comments.js
+++ b/application/config/github/gists/comments.js
@@ -17,7 +17,7 @@ var paramId = {
 };
 
 module.exports = {
-    name     : 'Comments',
+    name      : 'Comments',
     endpoints : [
         {
             name     : 'List comments on a gist',

--- a/application/config/github/git_data.js
+++ b/application/config/github/git_data.js
@@ -2,7 +2,7 @@
 
 module.exports = {
     name      : 'Git Data',
-    methods   : [],
+    endpoints   : [],
     resources : [
         require('./git_data/blobs'),
         require('./git_data/commits'),

--- a/application/config/github/git_data.js
+++ b/application/config/github/git_data.js
@@ -2,7 +2,7 @@
 
 module.exports = {
     name      : 'Git Data',
-    endpoints   : [],
+    endpoints : [],
     resources : [
         require('./git_data/blobs'),
         require('./git_data/commits'),

--- a/application/config/github/git_data/blobs.js
+++ b/application/config/github/git_data/blobs.js
@@ -43,7 +43,7 @@ var paramEncoding = {
 module.exports = {
     name     : 'Blobs',
     synopsis : 'Since blobs can be any arbitrary binary data, the input and responses for the blob API takes an encoding parameter that can be either `utf-8` or `base64`. If your data cannot be losslessly sent as a UTF-8 string, you can base64 encode it.',
-    methods : [
+    endpoints : [
         {
             name     : 'Get a Blob',
             synopsis : 'This API supports blobs up to 100 megabytes in size.',

--- a/application/config/github/git_data/blobs.js
+++ b/application/config/github/git_data/blobs.js
@@ -41,8 +41,8 @@ var paramEncoding = {
 };
 
 module.exports = {
-    name     : 'Blobs',
-    synopsis : 'Since blobs can be any arbitrary binary data, the input and responses for the blob API takes an encoding parameter that can be either `utf-8` or `base64`. If your data cannot be losslessly sent as a UTF-8 string, you can base64 encode it.',
+    name      : 'Blobs',
+    synopsis  : 'Since blobs can be any arbitrary binary data, the input and responses for the blob API takes an encoding parameter that can be either `utf-8` or `base64`. If your data cannot be losslessly sent as a UTF-8 string, you can base64 encode it.',
     endpoints : [
         {
             name     : 'Get a Blob',

--- a/application/config/github/git_data/commits.js
+++ b/application/config/github/git_data/commits.js
@@ -49,7 +49,7 @@ var paramParents = {
 };
 
 module.exports = {
-    name     : 'Commits',
+    name      : 'Commits',
     endpoints : [
         {
             name     : 'Get a Commit',

--- a/application/config/github/git_data/commits.js
+++ b/application/config/github/git_data/commits.js
@@ -50,7 +50,7 @@ var paramParents = {
 
 module.exports = {
     name     : 'Commits',
-    methods : [
+    endpoints : [
         {
             name     : 'Get a Commit',
             synopsis : '',

--- a/application/config/github/git_data/references.js
+++ b/application/config/github/git_data/references.js
@@ -26,7 +26,7 @@ var paramRef = {
 
 module.exports = {
     name     : 'References',
-    methods : [
+    endpoints : [
         {
             name     : 'Get a Reference',
             synopsis : '',

--- a/application/config/github/git_data/references.js
+++ b/application/config/github/git_data/references.js
@@ -25,7 +25,7 @@ var paramRef = {
 };
 
 module.exports = {
-    name     : 'References',
+    name      : 'References',
     endpoints : [
         {
             name     : 'Get a Reference',

--- a/application/config/github/git_data/tags.js
+++ b/application/config/github/git_data/tags.js
@@ -25,8 +25,8 @@ var paramSha = {
 };
 
 module.exports = {
-    name     : 'Tags',
-    synopsis : 'This tags API only deals with tag objects - so only annotated tags, not lightweight tags.',
+    name      : 'Tags',
+    synopsis  : 'This tags API only deals with tag objects - so only annotated tags, not lightweight tags.',
     endpoints : [
         {
             name     : 'Get a Tag',

--- a/application/config/github/git_data/tags.js
+++ b/application/config/github/git_data/tags.js
@@ -27,7 +27,7 @@ var paramSha = {
 module.exports = {
     name     : 'Tags',
     synopsis : 'This tags API only deals with tag objects - so only annotated tags, not lightweight tags.',
-    methods : [
+    endpoints : [
         {
             name     : 'Get a Tag',
             synopsis : '',

--- a/application/config/github/git_data/trees.js
+++ b/application/config/github/git_data/trees.js
@@ -26,7 +26,7 @@ var paramSha = {
 
 module.exports = {
     name     : 'Trees',
-    methods : [
+    endpoints : [
         {
             name     : 'Get a Tree',
             synopsis : '',

--- a/application/config/github/git_data/trees.js
+++ b/application/config/github/git_data/trees.js
@@ -25,7 +25,7 @@ var paramSha = {
 };
 
 module.exports = {
-    name     : 'Trees',
+    name      : 'Trees',
     endpoints : [
         {
             name     : 'Get a Tree',

--- a/application/config/github/issues.js
+++ b/application/config/github/issues.js
@@ -124,7 +124,7 @@ var paramOrg = {
 };
 
 module.exports = {
-    name    : 'Issues',
+    name      : 'Issues',
     endpoints : [
         {
             name     : 'List issues (all)',

--- a/application/config/github/issues.js
+++ b/application/config/github/issues.js
@@ -125,7 +125,7 @@ var paramOrg = {
 
 module.exports = {
     name    : 'Issues',
-    methods : [
+    endpoints : [
         {
             name     : 'List issues (all)',
             synopsis : 'List all issues across all the authenticated user’s visible repositories including owned repositories, member repositories, and organization repositories.',

--- a/application/config/github/issues/assignees.js
+++ b/application/config/github/issues/assignees.js
@@ -26,7 +26,7 @@ var paramAssignee = {
 
 module.exports = {
     name    : 'Assignees',
-    methods : [
+    endpoints : [
         {
             name     : 'List assignees',
             synopsis : 'This call lists all the available assignees (owner + collaborators) to which issues may be assigned.',

--- a/application/config/github/issues/assignees.js
+++ b/application/config/github/issues/assignees.js
@@ -25,7 +25,7 @@ var paramAssignee = {
 };
 
 module.exports = {
-    name    : 'Assignees',
+    name      : 'Assignees',
     endpoints : [
         {
             name     : 'List assignees',

--- a/application/config/github/issues/comments.js
+++ b/application/config/github/issues/comments.js
@@ -76,7 +76,7 @@ var paramBody = {
 
 module.exports = {
     name    : 'Comments',
-    methods : [
+    endpoints : [
         {
             name     : 'List comments on an issue',
             synopsis : '',

--- a/application/config/github/issues/comments.js
+++ b/application/config/github/issues/comments.js
@@ -75,7 +75,7 @@ var paramBody = {
 };
 
 module.exports = {
-    name    : 'Comments',
+    name      : 'Comments',
     endpoints : [
         {
             name     : 'List comments on an issue',

--- a/application/config/github/issues/events.js
+++ b/application/config/github/issues/events.js
@@ -25,7 +25,7 @@ var paramIssueNumber = {
 };
 
 module.exports = {
-    name    : 'Events',
+    name      : 'Events',
     endpoints : [
         {
             name     : 'List events for an issue',

--- a/application/config/github/issues/events.js
+++ b/application/config/github/issues/events.js
@@ -26,7 +26,7 @@ var paramIssueNumber = {
 
 module.exports = {
     name    : 'Events',
-    methods : [
+    endpoints : [
         {
             name     : 'List events for an issue',
             synopsis : '',

--- a/application/config/github/issues/labels.js
+++ b/application/config/github/issues/labels.js
@@ -58,7 +58,7 @@ var paramMilestoneNumber = {
 
 module.exports = {
     name    : 'Labels',
-    methods : [
+    endpoints : [
         {
             name     : 'List all labels for this repository',
             synopsis : '',

--- a/application/config/github/issues/labels.js
+++ b/application/config/github/issues/labels.js
@@ -57,7 +57,7 @@ var paramMilestoneNumber = {
 };
 
 module.exports = {
-    name    : 'Labels',
+    name      : 'Labels',
     endpoints : [
         {
             name     : 'List all labels for this repository',

--- a/application/config/github/issues/milestones.js
+++ b/application/config/github/issues/milestones.js
@@ -65,7 +65,7 @@ var paramNumber = {
 
 module.exports = {
     name    : 'Milestones',
-    methods : [
+    endpoints : [
         {
             name     : 'List milestones for a repository',
             synopsis : '',

--- a/application/config/github/issues/milestones.js
+++ b/application/config/github/issues/milestones.js
@@ -64,7 +64,7 @@ var paramNumber = {
 };
 
 module.exports = {
-    name    : 'Milestones',
+    name      : 'Milestones',
     endpoints : [
         {
             name     : 'List milestones for a repository',

--- a/application/config/github/miscellaneous.js
+++ b/application/config/github/miscellaneous.js
@@ -2,7 +2,7 @@
 
 module.exports = {
     name      : 'Miscellaneous',
-    methods   : [],
+    endpoints   : [],
     resources : [
         require('./miscellaneous/emojis'),
         require('./miscellaneous/gitignore'),

--- a/application/config/github/miscellaneous.js
+++ b/application/config/github/miscellaneous.js
@@ -2,7 +2,7 @@
 
 module.exports = {
     name      : 'Miscellaneous',
-    endpoints   : [],
+    endpoints : [],
     resources : [
         require('./miscellaneous/emojis'),
         require('./miscellaneous/gitignore'),

--- a/application/config/github/miscellaneous/emojis.js
+++ b/application/config/github/miscellaneous/emojis.js
@@ -3,7 +3,7 @@
 module.exports = {
     name     : 'Emojis',
     synopsis : 'Lists all the emojis available to use on GitHub.',
-    methods : [
+    endpoints : [
         {
             name     : 'Emojis',
             synopsis : '',

--- a/application/config/github/miscellaneous/emojis.js
+++ b/application/config/github/miscellaneous/emojis.js
@@ -1,8 +1,8 @@
 'use strict';
 
 module.exports = {
-    name     : 'Emojis',
-    synopsis : 'Lists all the emojis available to use on GitHub.',
+    name      : 'Emojis',
+    synopsis  : 'Lists all the emojis available to use on GitHub.',
     endpoints : [
         {
             name     : 'Emojis',

--- a/application/config/github/miscellaneous/gitignore.js
+++ b/application/config/github/miscellaneous/gitignore.js
@@ -9,8 +9,8 @@ var paramTemplate = {
 };
 
 module.exports = {
-    name     : 'Gitignore',
-    synopsis : 'When you create a new GitHub repository via the API, you can specify a .gitignore template to apply to the repository upon creation. The .gitignore Templates API lists and fetches templates from the GitHub .gitignore repository.',
+    name      : 'Gitignore',
+    synopsis  : 'When you create a new GitHub repository via the API, you can specify a .gitignore template to apply to the repository upon creation. The .gitignore Templates API lists and fetches templates from the GitHub .gitignore repository.',
     endpoints : [
         {
             name     : 'Listing available templates',

--- a/application/config/github/miscellaneous/gitignore.js
+++ b/application/config/github/miscellaneous/gitignore.js
@@ -11,7 +11,7 @@ var paramTemplate = {
 module.exports = {
     name     : 'Gitignore',
     synopsis : 'When you create a new GitHub repository via the API, you can specify a .gitignore template to apply to the repository upon creation. The .gitignore Templates API lists and fetches templates from the GitHub .gitignore repository.',
-    methods : [
+    endpoints : [
         {
             name     : 'Listing available templates',
             synopsis : 'List all templates available to pass as an option when creating a repository.',

--- a/application/config/github/miscellaneous/markdown.js
+++ b/application/config/github/miscellaneous/markdown.js
@@ -30,7 +30,7 @@ var paramContext = {
 };
 
 module.exports = {
-    name     : 'Markdown',
+    name      : 'Markdown',
     endpoints : [
         {
             name     : 'Render an arbitrary Markdown document',

--- a/application/config/github/miscellaneous/markdown.js
+++ b/application/config/github/miscellaneous/markdown.js
@@ -31,7 +31,7 @@ var paramContext = {
 
 module.exports = {
     name     : 'Markdown',
-    methods : [
+    endpoints : [
         {
             name     : 'Render an arbitrary Markdown document',
             synopsis : '',

--- a/application/config/github/miscellaneous/meta.js
+++ b/application/config/github/miscellaneous/meta.js
@@ -3,7 +3,7 @@
 module.exports = {
     name     : 'Meta',
     synopsis : 'This endpoint provides information about GitHub.com, the service. Or, if you access this endpoint on your organization’s GitHub Enterprise installation, this endpoint provides information about that installation.',
-    methods : [
+    endpoints : [
         {
             name     : 'Meta',
             synopsis : '',

--- a/application/config/github/miscellaneous/meta.js
+++ b/application/config/github/miscellaneous/meta.js
@@ -1,8 +1,8 @@
 'use strict';
 
 module.exports = {
-    name     : 'Meta',
-    synopsis : 'This endpoint provides information about GitHub.com, the service. Or, if you access this endpoint on your organization’s GitHub Enterprise installation, this endpoint provides information about that installation.',
+    name      : 'Meta',
+    synopsis  : 'This endpoint provides information about GitHub.com, the service. Or, if you access this endpoint on your organization’s GitHub Enterprise installation, this endpoint provides information about that installation.',
     endpoints : [
         {
             name     : 'Meta',

--- a/application/config/github/miscellaneous/rate_limit.js
+++ b/application/config/github/miscellaneous/rate_limit.js
@@ -1,8 +1,8 @@
 'use strict';
 
 module.exports = {
-    name     : 'Rate Limit',
-    synopsis : 'The overview documentation describes the rate limit rules. You can check your current rate limit status at any time using the Rate Limit API described below.',
+    name      : 'Rate Limit',
+    synopsis  : 'The overview documentation describes the rate limit rules. You can check your current rate limit status at any time using the Rate Limit API described below.',
     endpoints : [
         {
             name     : 'Get your current rate limit status',

--- a/application/config/github/miscellaneous/rate_limit.js
+++ b/application/config/github/miscellaneous/rate_limit.js
@@ -3,7 +3,7 @@
 module.exports = {
     name     : 'Rate Limit',
     synopsis : 'The overview documentation describes the rate limit rules. You can check your current rate limit status at any time using the Rate Limit API described below.',
-    methods : [
+    endpoints : [
         {
             name     : 'Get your current rate limit status',
             synopsis : 'Note: Accessing this endpoint does not count against your rate limit.',

--- a/application/config/github/organizations.js
+++ b/application/config/github/organizations.js
@@ -66,7 +66,7 @@ var paramDescription = {
 
 module.exports = {
     name    : 'Organizations',
-    methods : [
+    endpoints : [
         {
             name     : 'List User Organizations (all)',
             synopsis : 'List all public organizations for an unauthenticated user. Lists private and public organizations for authenticated users.',

--- a/application/config/github/organizations.js
+++ b/application/config/github/organizations.js
@@ -65,7 +65,7 @@ var paramDescription = {
 };
 
 module.exports = {
-    name    : 'Organizations',
+    name      : 'Organizations',
     endpoints : [
         {
             name     : 'List User Organizations (all)',

--- a/application/config/github/organizations.js
+++ b/application/config/github/organizations.js
@@ -56,6 +56,14 @@ var paramName = {
     description  : 'The shorthand name of the company.'
 };
 
+var paramDescription = {
+    name         : 'description',
+    required     : false,
+    type         : 'string',
+    location     : 'body',
+    description  : 'The description of the company.'
+};
+
 module.exports = {
     name    : 'Organizations',
     methods : [
@@ -99,7 +107,8 @@ module.exports = {
                 paramCompany,
                 paramEmail,
                 paramLocation,
-                paramName
+                paramName,
+                paramDescription
             ]
         }
     ],

--- a/application/config/github/organizations/members.js
+++ b/application/config/github/organizations/members.js
@@ -30,7 +30,7 @@ var paramUser = {
 };
 
 module.exports = {
-    name    : 'Members',
+    name      : 'Members',
     endpoints : [
         {
             name     : 'Members list',

--- a/application/config/github/organizations/members.js
+++ b/application/config/github/organizations/members.js
@@ -107,6 +107,49 @@ module.exports = {
                 paramOrg,
                 paramUser
             ]
+        },
+        {
+            name     : 'List your organization memberships',
+            synopsis : '',
+            method   : 'GET',
+            uri      : '/user/memberships/orgs',
+            oauth    : true,
+            params   : [
+                {
+                    name         : 'state',
+                    required     : false,
+                    type         : 'string',
+                    location     : 'query',
+                    description  : 'Indicates the state of the memberships to return. Can be either active or pending. If not specified, both active and pending memberships are returned.'
+                }
+            ]
+        },
+        {
+            name     : 'Get your organization membership',
+            synopsis : '',
+            method   : 'GET',
+            uri      : '/user/memberships/orgs/:org',
+            oauth    : true,
+            params   : [
+                paramOrg
+            ]
+        },
+        {
+            name     : 'Edit your organization membership',
+            synopsis : '',
+            method   : 'PATCH',
+            uri      : '/user/memberships/orgs/:org',
+            oauth    : true,
+            params   : [
+                paramOrg,
+                {
+                    name         : 'state',
+                    required     : true,
+                    type         : 'string',
+                    location     : 'body',
+                    description  : 'The state that the membership should be in. Only "active" will be accepted.'
+                }
+            ]
         }
     ]
 };

--- a/application/config/github/organizations/members.js
+++ b/application/config/github/organizations/members.js
@@ -31,7 +31,7 @@ var paramUser = {
 
 module.exports = {
     name    : 'Members',
-    methods : [
+    endpoints : [
         {
             name     : 'Members list',
             synopsis : 'List all users who are members of an organization. A member is a user that belongs to at least 1 team in the organization. If the authenticated user is also an owner of this organization then both concealed and public members will be returned. If the requester is not an owner of the organization the query will be redirected to the public members list.',

--- a/application/config/github/organizations/teams.js
+++ b/application/config/github/organizations/teams.js
@@ -24,6 +24,14 @@ var paramName = {
     description : 'The name of the team.'
 };
 
+var paramDescription = {
+    name        : 'description',
+    required    : false,
+    type        : 'string',
+    location    : 'body',
+    description : 'The description of the team.'
+};
+
 var paramRepoNames = {
     name        : 'repo_names',
     required    : false,
@@ -103,6 +111,7 @@ module.exports = {
             params   : [
                 paramOrg,
                 paramName,
+                paramDescription,
                 paramRepoNames,
                 paramPermission
             ]
@@ -116,6 +125,7 @@ module.exports = {
             params   : [
                 paramId,
                 paramName,
+                paramDescription,
                 paramPermission
             ]
         },
@@ -140,7 +150,7 @@ module.exports = {
             ]
         },
         {
-            name     : 'Get team member',
+            name     : 'Get team member (Deprecated)',
             synopsis : 'In order to get if a user is a member of a team, the authenticated user must be a member of the team.',
             method   : 'GET',
             uri      : '/teams/:id/members/:user',
@@ -151,7 +161,7 @@ module.exports = {
             ]
         },
         {
-            name     : 'Add team member',
+            name     : 'Add team member (Deprecated)',
             synopsis : 'In order to add a user to a team, the authenticated user must have ‘admin’ permissions to the team or be an owner of the org that the team is associated with.',
             method   : 'PUT',
             uri      : '/teams/:id/members/:user',
@@ -162,10 +172,43 @@ module.exports = {
             ]
         },
         {
-            name     : 'Remove team member',
+            name     : 'Remove team member (Deprecated)',
             synopsis : 'In order to remove a user from a team, the authenticated user must have ‘admin’ permissions to the team or be an owner of the org that the team is associated with. NOTE: This does not delete the user, it just remove them from the team.',
             method   : 'DELETE',
             uri      : '/teams/:id/members/:user',
+            oauth    : true,
+            params   : [
+                paramId,
+                paramUser
+            ]
+        },
+        {
+            name     : 'Get Team Membership',
+            synopsis : 'In order to get a user’s membership with a team, the authenticated user must be a member of the team or an owner of the team’s organization.',
+            method   : 'GET',
+            uri      : '/teams/:id/memberships/:user',
+            oauth    : true,
+            params   : [
+                paramId,
+                paramUser
+            ]
+        },
+        {
+            name     : 'Add Team Membership',
+            synopsis : 'In order to add a membership between a user and a team, the authenticated user must have ‘admin’ permissions to the team or be an owner of the organization that the team is associated with. If the user is already a part of the team’s organization (meaning they’re on at least one other team in the organization), this endpoint will add the user to the team. If the user is completely unaffiliated with the team’s organization (meaning they’re on none of the organization’s teams), this endpoint will send an invitation to the user via email. This newly-created membership will be in the “pending” state until the user accepts the invitation, at which point the membership will transition to the “active” state and the user will be added as a member of the team.',
+            method   : 'PUT',
+            uri      : '/teams/:id/memberships/:user',
+            oauth    : true,
+            params   : [
+                paramId,
+                paramUser
+            ]
+        },
+        {
+            name     : 'Remove Team Membership',
+            synopsis : 'In order to remove a membership between a user and a team, the authenticated user must have ‘admin’ permissions to the team or be an owner of the organization that the team is associated with. NOTE: This does not delete the user, it just removes their membership from the team.',
+            method   : 'DELETE',
+            uri      : '/teams/:id/memberships/:user',
             oauth    : true,
             params   : [
                 paramId,

--- a/application/config/github/organizations/teams.js
+++ b/application/config/github/organizations/teams.js
@@ -81,7 +81,7 @@ var paramRepo = {
 module.exports = {
     name     : 'Teams',
     synopsis : 'All actions against teams require at a minimum an authenticated user who is a member of the Owners team in the `:org` being managed. Additionally, OAuth users require the “read:org” scope.', 
-    methods : [
+    endpoints : [
         {
             name     : 'List teams',
             synopsis : '',

--- a/application/config/github/organizations/teams.js
+++ b/application/config/github/organizations/teams.js
@@ -79,8 +79,8 @@ var paramRepo = {
 };
 
 module.exports = {
-    name     : 'Teams',
-    synopsis : 'All actions against teams require at a minimum an authenticated user who is a member of the Owners team in the `:org` being managed. Additionally, OAuth users require the “read:org” scope.', 
+    name      : 'Teams',
+    synopsis  : 'All actions against teams require at a minimum an authenticated user who is a member of the Owners team in the `:org` being managed. Additionally, OAuth users require the “read:org” scope.', 
     endpoints : [
         {
             name     : 'List teams',

--- a/application/config/github/pull_requests.js
+++ b/application/config/github/pull_requests.js
@@ -83,8 +83,8 @@ var paramNumber = {
 };
 
 module.exports = {
-    name     : 'Pull Requests',
-    synopsis : 'The Pull Request API allows you to list, view, edit, create, and even merge pull requests. Comments on pull requests can be managed via the Issue Comments API.',
+    name      : 'Pull Requests',
+    synopsis  : 'The Pull Request API allows you to list, view, edit, create, and even merge pull requests. Comments on pull requests can be managed via the Issue Comments API.',
     endpoints : [
         {
             name     : 'List pull requests',

--- a/application/config/github/pull_requests.js
+++ b/application/config/github/pull_requests.js
@@ -85,7 +85,7 @@ var paramNumber = {
 module.exports = {
     name     : 'Pull Requests',
     synopsis : 'The Pull Request API allows you to list, view, edit, create, and even merge pull requests. Comments on pull requests can be managed via the Issue Comments API.',
-    methods : [
+    endpoints : [
         {
             name     : 'List pull requests',
             synopsis : '',

--- a/application/config/github/pull_requests/review_comments.js
+++ b/application/config/github/pull_requests/review_comments.js
@@ -67,8 +67,8 @@ var paramSince = {
 };
 
 module.exports = {
-    name     : 'Review Comments',
-    synopsis : 'Pull Request Review Comments are comments on a portion of the unified diff. These are separate from Commit Comments (which are applied directly to a commit, outside of the Pull Request view), and Issue Comments (which do not reference a portion of the unified diff).',
+    name      : 'Review Comments',
+    synopsis  : 'Pull Request Review Comments are comments on a portion of the unified diff. These are separate from Commit Comments (which are applied directly to a commit, outside of the Pull Request view), and Issue Comments (which do not reference a portion of the unified diff).',
     endpoints : [
         {
             name     : 'List comments on a pull request',

--- a/application/config/github/pull_requests/review_comments.js
+++ b/application/config/github/pull_requests/review_comments.js
@@ -69,7 +69,7 @@ var paramSince = {
 module.exports = {
     name     : 'Review Comments',
     synopsis : 'Pull Request Review Comments are comments on a portion of the unified diff. These are separate from Commit Comments (which are applied directly to a commit, outside of the Pull Request view), and Issue Comments (which do not reference a portion of the unified diff).',
-    methods : [
+    endpoints : [
         {
             name     : 'List comments on a pull request',
             synopsis : '',

--- a/application/config/github/repositories.js
+++ b/application/config/github/repositories.js
@@ -34,7 +34,7 @@ var paramOrg = {
 
 module.exports = {
     name     : 'Repositories',
-    methods : [
+    endpoints : [
         {
             name     : 'List your repositories',
             synopsis : 'List repositories for the authenticated user. Note that this does not include repositories owned by organizations which the user can access. You can list user organizations and list organization repositories separately.',

--- a/application/config/github/repositories.js
+++ b/application/config/github/repositories.js
@@ -33,7 +33,7 @@ var paramOrg = {
 };
 
 module.exports = {
-    name     : 'Repositories',
+    name      : 'Repositories',
     endpoints : [
         {
             name     : 'List your repositories',

--- a/application/config/github/repositories.js
+++ b/application/config/github/repositories.js
@@ -539,6 +539,7 @@ module.exports = {
         require('./repositories/commits'),
         require('./repositories/contents'),
         require('./repositories/deploy_keys'),
+        require('./repositories/deployments'),
         require('./repositories/forks'),
         require('./repositories/hooks'),
         require('./repositories/merging'),

--- a/application/config/github/repositories/collaborators.js
+++ b/application/config/github/repositories/collaborators.js
@@ -25,7 +25,7 @@ var paramUsername = {
 };
 
 module.exports = {
-    name     : 'Collaborators',
+    name      : 'Collaborators',
     endpoints : [
         {
             name     : 'List collaborators',

--- a/application/config/github/repositories/collaborators.js
+++ b/application/config/github/repositories/collaborators.js
@@ -26,7 +26,7 @@ var paramUsername = {
 
 module.exports = {
     name     : 'Collaborators',
-    methods : [
+    endpoints : [
         {
             name     : 'List collaborators',
             synopsis : 'When authenticating as an organization owner of an organization-owned repository, all organization owners are included in the list of collaborators. Otherwise, only users with access to the repository are returned in the collaborators list.',

--- a/application/config/github/repositories/comments.js
+++ b/application/config/github/repositories/comments.js
@@ -33,7 +33,7 @@ var paramId = {
 };
 
 module.exports = {
-    name     : 'Comments',
+    name      : 'Comments',
     endpoints : [
         {
             name     : 'List commit comments for a repository',

--- a/application/config/github/repositories/comments.js
+++ b/application/config/github/repositories/comments.js
@@ -34,7 +34,7 @@ var paramId = {
 
 module.exports = {
     name     : 'Comments',
-    methods : [
+    endpoints : [
         {
             name     : 'List commit comments for a repository',
             synopsis : '',

--- a/application/config/github/repositories/commits.js
+++ b/application/config/github/repositories/commits.js
@@ -19,7 +19,7 @@ var paramRepo = {
 };
 
 module.exports = {
-    name     : 'Commits',
+    name      : 'Commits',
     endpoints : [
         {
             name     : 'List commits on a repository',

--- a/application/config/github/repositories/commits.js
+++ b/application/config/github/repositories/commits.js
@@ -20,7 +20,7 @@ var paramRepo = {
 
 module.exports = {
     name     : 'Commits',
-    methods : [
+    endpoints : [
         {
             name     : 'List commits on a repository',
             synopsis : '',

--- a/application/config/github/repositories/contents.js
+++ b/application/config/github/repositories/contents.js
@@ -26,7 +26,7 @@ var paramPath = {
 
 module.exports = {
     name     : 'Contents',
-    methods : [
+    endpoints : [
         {
             name     : 'Get the README',
             synopsis : '',

--- a/application/config/github/repositories/contents.js
+++ b/application/config/github/repositories/contents.js
@@ -25,7 +25,7 @@ var paramPath = {
 };
 
 module.exports = {
-    name     : 'Contents',
+    name      : 'Contents',
     endpoints : [
         {
             name     : 'Get the README',

--- a/application/config/github/repositories/contents.js
+++ b/application/config/github/repositories/contents.js
@@ -39,7 +39,7 @@ module.exports = {
                 {
                     name         : 'ref',
                     required     : false,
-                    defaultValue : 'the repository’s default branch (usually master)',
+                    defaultValue : 'master',
                     type         : 'string',
                     location     : 'uri',
                     description  : 'The name of the commit/branch/tag.'
@@ -59,7 +59,7 @@ module.exports = {
                 {
                     name         : 'ref',
                     required     : false,
-                    defaultValue : 'the repository’s default branch (usually master)',
+                    defaultValue : 'master',
                     type         : 'string',
                     location     : 'uri',
                     description  : 'The name of the commit/branch/tag.'
@@ -93,7 +93,7 @@ module.exports = {
                 {
                     name         : 'branch',
                     required     : false,
-                    defaultValue : 'the repository’s default branch (usually master)',
+                    defaultValue : 'master',
                     type         : 'string',
                     location     : 'body',
                     description  : 'The branch name.'
@@ -134,7 +134,7 @@ module.exports = {
                 {
                     name         : 'branch',
                     required     : false,
-                    defaultValue : 'the repository’s default branch (usually master)',
+                    defaultValue : 'master',
                     type         : 'string',
                     location     : 'body',
                     description  : 'The branch name.'
@@ -168,7 +168,7 @@ module.exports = {
                 {
                     name         : 'branch',
                     required     : false,
-                    defaultValue : 'the repository’s default branch (usually master)',
+                    defaultValue : 'master',
                     type         : 'string',
                     location     : 'body',
                     description  : 'The branch name.'
@@ -199,7 +199,7 @@ module.exports = {
                 {
                     name         : 'ref',
                     required     : true,
-                    defaultValue : 'the repository’s default branch (usually master)',
+                    defaultValue : 'master',
                     type         : 'string',
                     location     : 'uri',
                     description  : 'A valid Git reference.'

--- a/application/config/github/repositories/deploy_keys.js
+++ b/application/config/github/repositories/deploy_keys.js
@@ -26,7 +26,7 @@ var paramId = {
 
 
 module.exports = {
-    name     : 'Deploy Keys',
+    name      : 'Deploy Keys',
     endpoints : [
         {
             name     : 'List deploy keys',

--- a/application/config/github/repositories/deploy_keys.js
+++ b/application/config/github/repositories/deploy_keys.js
@@ -27,7 +27,7 @@ var paramId = {
 
 module.exports = {
     name     : 'Deploy Keys',
-    methods : [
+    endpoints : [
         {
             name     : 'List deploy keys',
             synopsis : '',

--- a/application/config/github/repositories/deployments.js
+++ b/application/config/github/repositories/deployments.js
@@ -18,7 +18,7 @@ var paramRepo = {
 
 module.exports = {
     name     : 'Deployments',
-    methods : [
+    endpoints : [
         {
             name     : 'List Deployments',
             synopsis : 'Simple filtering of deployments is available via query parameters.',

--- a/application/config/github/repositories/deployments.js
+++ b/application/config/github/repositories/deployments.js
@@ -17,7 +17,7 @@ var paramRepo = {
 };
 
 module.exports = {
-    name     : 'Deployments',
+    name      : 'Deployments',
     endpoints : [
         {
             name     : 'List Deployments',

--- a/application/config/github/repositories/deployments.js
+++ b/application/config/github/repositories/deployments.js
@@ -1,0 +1,202 @@
+'use strict';
+
+var paramOwner = {
+    name        : 'owner',
+    required    : true,
+    type        : 'string',
+    location    : 'uri',
+    description : 'The owner of the repo.'
+};
+
+var paramRepo = {
+    name        : 'repo',
+    required    : true,
+    type        : 'string',
+    location    : 'uri',
+    description : 'The name of the repo.'
+};
+
+module.exports = {
+    name     : 'Deployments',
+    methods : [
+        {
+            name     : 'List Deployments',
+            synopsis : 'Simple filtering of deployments is available via query parameters.',
+            method   : 'GET',
+            uri      : '/repos/:owner/:repo/deployments',
+            oauth    : false,
+            params   : [
+                paramOwner,
+                paramRepo,
+                {
+                    name         : 'sha',
+                    required     : false,
+                    defaultValue : 'none',
+                    type         : 'string',
+                    location     : 'query',
+                    description  : 'The short or long sha that was recorded at creation time.'
+                },
+                {
+                    name         : 'ref',
+                    required     : false,
+                    defaultValue : 'none',
+                    type         : 'string',
+                    location     : 'query',
+                    description  : 'The name of the ref. This can be a branch, tag, or sha.'
+                },
+                {
+                    name         : 'task',
+                    required     : false,
+                    defaultValue : 'none',
+                    type         : 'string',
+                    location     : 'query',
+                    description  : 'The name of the task for the deployment. e.g. deploy or deploy:migrations.'
+                },
+                {
+                    name         : 'environment',
+                    required     : false,
+                    defaultValue : 'none',
+                    type         : 'string',
+                    location     : 'query',
+                    description  : 'The name of the environment that was deployed to. e.g. staging or production.'
+                }
+            ]
+        },
+        {
+            name     : 'Create Deployment',
+            synopsis : 'Deployments offer a few configurable parameters with sane defaults.',
+            method   : 'POST',
+            uri      : '/repos/:owner/:repo/deployments',
+            oauth    : true,
+            params   : [
+                paramOwner,
+                paramRepo,
+                {
+                    name         : 'ref',
+                    required     : true,
+                    defaultValue : '',
+                    type         : 'string',
+                    location     : 'body',
+                    description  : 'The ref to deploy. This can be a branch, tag, or sha.'
+                },
+                {
+                    name         : 'task',
+                    required     : false,
+                    defaultValue : 'deploy',
+                    type         : 'string',
+                    location     : 'body',
+                    description  : 'Optional parameter to specify a task to execute, e.g. deploy or deploy:migrations.'
+                },
+                {
+                    name         : 'auto_merge',
+                    required     : false,
+                    defaultValue : 'true',
+                    type         : 'boolean',
+                    location     : 'body',
+                    description  : 'Optional parameter to merge the default branch into the requested ref if it is behind the default branch.'
+                },
+                {
+                    name         : 'required_contexts',
+                    required     : false,
+                    defaultValue : '',
+                    type         : 'array',
+                    location     : 'body',
+                    description  : 'Optional array of status contexts verified against commit status checks. If this parameter is omitted from the parameters then all unique contexts will be verified before a deployment is created. To bypass checking entirely pass an empty array. Defaults to all unique contexts.'
+                },
+                {
+                    name         : 'payload',
+                    required     : false,
+                    defaultValue : '',
+                    type         : 'string',
+                    location     : 'body',
+                    description  : 'Optional JSON payload with extra information about the deployment.'
+                },
+                {
+                    name         : 'environment',
+                    required     : false,
+                    defaultValue : 'production',
+                    type         : 'string',
+                    location     : 'body',
+                    description  : 'Optional name for the target deployment environment (e.g., production, staging, qa).'
+                },
+                {
+                    name         : 'description',
+                    required     : false,
+                    defaultValue : '',
+                    type         : 'string',
+                    location     : 'body',
+                    description  : 'Optional short description.'
+                }
+            ]
+        },
+        {
+            name     : 'List Deployment Statuses',
+            synopsis : 'Users with pull access can view deployment statuses for a deployment.',
+            method   : 'GET',
+            uri      : '/repos/:owner/:repo/deployments/:id/statuses',
+            oauth    : false,
+            params   : [
+                paramOwner,
+                paramRepo,
+                {
+                    name         : 'id',
+                    required     : true,
+                    defaultValue : '',
+                    type         : 'integer',
+                    location     : 'uri',
+                    description  : 'The Deployment ID to list the statuses from.'
+                }
+            ]
+        },
+        {
+            name     : 'Create a Deployment Status',
+            synopsis : 'Users with push access can create deployment statuses for a given deployment.',
+            method   : 'POST',
+            uri      : '/repos/:owner/:repo/deployments/:id/statuses',
+            oauth    : true,
+            params   : [
+                paramOwner,
+                paramRepo,
+                {
+                    name         : 'id',
+                    required     : true,
+                    defaultValue : '',
+                    type         : 'integer',
+                    location     : 'uri',
+                    description  : 'The Deployment ID for which to create the status.'
+                },
+                {
+                    name         : 'state',
+                    required     : true,
+                    defaultValue : '',
+                    type         : 'enum',
+                    location     : 'body',
+                    description  : 'The state of the status. Can be one of pending, success, error, or failure.',
+                    enumValues   : [
+                        null,
+                        'pending',
+                        'success',
+                        'error',
+                        'failure'
+                    ]
+                },
+                {
+                    name         : 'target_url',
+                    required     : false,
+                    defaultValue : '',
+                    type         : 'string',
+                    location     : 'body',
+                    description  : 'The target URL to associate with this status. This URL should contain output to keep the user updated while the task is running or serve as historical information for what happened in the deployment.'
+                },
+                {
+                    name         : 'description',
+                    required     : false,
+                    defaultValue : '',
+                    type         : 'string',
+                    location     : 'body',
+                    description  : 'A short description of the status.'
+                }
+            ]
+        }
+    ]
+};

--- a/application/config/github/repositories/forks.js
+++ b/application/config/github/repositories/forks.js
@@ -17,7 +17,7 @@ var paramRepo = {
 };
 
 module.exports = {
-    name     : 'Forks',
+    name      : 'Forks',
     endpoints : [
         {
             name     : 'List forks',

--- a/application/config/github/repositories/forks.js
+++ b/application/config/github/repositories/forks.js
@@ -18,7 +18,7 @@ var paramRepo = {
 
 module.exports = {
     name     : 'Forks',
-    methods : [
+    endpoints : [
         {
             name     : 'List forks',
             synopsis : '',

--- a/application/config/github/repositories/hooks.js
+++ b/application/config/github/repositories/hooks.js
@@ -25,7 +25,7 @@ var paramId = {
 };
 
 module.exports = {
-    name     : 'Hooks',
+    name      : 'Hooks',
     endpoints : [
         {
             name     : 'List hooks',

--- a/application/config/github/repositories/hooks.js
+++ b/application/config/github/repositories/hooks.js
@@ -26,7 +26,7 @@ var paramId = {
 
 module.exports = {
     name     : 'Hooks',
-    methods : [
+    endpoints : [
         {
             name     : 'List hooks',
             synopsis : '',

--- a/application/config/github/repositories/hooks.js
+++ b/application/config/github/repositories/hooks.js
@@ -91,6 +91,56 @@ module.exports = {
             ]
         },
         {
+            name     : 'Edit a hook',
+            synopsis : '',
+            method   : 'POST',
+            uri      : '/repos/:owner/:repo/hooks/:id',
+            oauth    : true,
+            params   : [
+                paramOwner,
+                paramRepo,
+                paramId,
+                {
+                    name        : 'config',
+                    required    : true,
+                    type        : 'hash with variable keys',
+                    location    : 'body',
+                    description : 'Key/value pairs to provide settings for this hook. These settings vary between the services and are defined in the github-services repository. Booleans are stored internally as “1” for true, and “0” for false. Any JSON true/false values will be converted automatically.'
+                },
+                {
+                    name         : 'events',
+                    required     : false,
+                    defaultValue : ['push'],
+                    type         : 'array[string]',
+                    location     : 'body',
+                    description  : 'Determines what events the hook is triggered for.'
+                },
+                {
+                    name         : 'add_events',
+                    required     : false,
+                    defaultValue : '',
+                    type         : 'array[string]',
+                    location     : 'body',
+                    description  : 'Determines a list of events to be added to the list of events that the Hook triggers for.'
+                },
+                {
+                    name         : 'remove_events',
+                    required     : false,
+                    defaultValue : '',
+                    type         : 'array[string]',
+                    location     : 'body',
+                    description  : 'Determines a list of events to be removed from the list of events that the Hook triggers for.'
+                },
+                {
+                    name        : 'active',
+                    required    : false,
+                    type        : 'boolean',
+                    location    : 'body',
+                    description : 'Determines whether the hook is actually triggered on pushes.'
+                }
+            ]
+        },
+        {
             name     : 'Test a push hook',
             synopsis : 'This will trigger the hook with the latest push to the current repository if the hook is subscribed to push events. If the hook is not subscribed to push events, the server will respond with 204 but no test POST will be generated.',
             method   : 'POST',

--- a/application/config/github/repositories/merging.js
+++ b/application/config/github/repositories/merging.js
@@ -18,7 +18,7 @@ var paramRepo = {
 
 module.exports = {
     name     : 'Merging',
-    methods : [
+    endpoints : [
         {
             name     : 'Perform a Merge',
             synopsis : '',

--- a/application/config/github/repositories/merging.js
+++ b/application/config/github/repositories/merging.js
@@ -17,7 +17,7 @@ var paramRepo = {
 };
 
 module.exports = {
-    name     : 'Merging',
+    name      : 'Merging',
     endpoints : [
         {
             name     : 'Perform a Merge',

--- a/application/config/github/repositories/pages.js
+++ b/application/config/github/repositories/pages.js
@@ -17,7 +17,7 @@ var paramRepo = {
 };
 
 module.exports = {
-    name     : 'Pages',
+    name      : 'Pages',
     endpoints : [
         {
             name     : 'Get information about a Pages site',

--- a/application/config/github/repositories/pages.js
+++ b/application/config/github/repositories/pages.js
@@ -18,7 +18,7 @@ var paramRepo = {
 
 module.exports = {
     name     : 'Pages',
-    methods : [
+    endpoints : [
         {
             name     : 'Get information about a Pages site',
             synopsis : '',

--- a/application/config/github/repositories/releases.js
+++ b/application/config/github/repositories/releases.js
@@ -25,7 +25,7 @@ var paramId = {
 };
 
 module.exports = {
-    name     : 'Releases',
+    name      : 'Releases',
     endpoints : [
         {
             name     : 'List releases for a repository',

--- a/application/config/github/repositories/releases.js
+++ b/application/config/github/repositories/releases.js
@@ -26,7 +26,7 @@ var paramId = {
 
 module.exports = {
     name     : 'Releases',
-    methods : [
+    endpoints : [
         {
             name     : 'List releases for a repository',
             synopsis : '',

--- a/application/config/github/repositories/releases.js
+++ b/application/config/github/repositories/releases.js
@@ -51,6 +51,35 @@ module.exports = {
             ]
         },
         {
+            name     : 'Get the latest release',
+            synopsis : 'View the latest published release for the repository.',
+            method   : 'GET',
+            uri      : '/repos/:owner/:repo/releases/latest',
+            oauth    : false,
+            params   : [
+                paramOwner,
+                paramRepo
+            ]
+        },
+        {
+            name     : 'Get a release by tag name',
+            synopsis : 'Get a release with the specified tag. Users must have push access to the repository to view draft releases.',
+            method   : 'GET',
+            uri      : '/repos/:owner/:repo/releases/tags/:tag',
+            oauth    : false,
+            params   : [
+                paramOwner,
+                paramRepo,
+                {
+                    name         : 'tag',
+                    required     : true,
+                    type         : 'string',
+                    location     : 'uri',
+                    description  : 'The name of the tag.'
+                },
+            ]
+        },
+        {
             name     : 'Create a release',
             synopsis : '',
             method   : 'POST',

--- a/application/config/github/repositories/statistics.js
+++ b/application/config/github/repositories/statistics.js
@@ -17,7 +17,7 @@ var paramRepo = {
 };
 
 module.exports = {
-    name     : 'Statistics',
+    name      : 'Statistics',
     endpoints : [
         {
             name     : 'Get contributors list with additions, deletions, and commit counts',

--- a/application/config/github/repositories/statistics.js
+++ b/application/config/github/repositories/statistics.js
@@ -18,7 +18,7 @@ var paramRepo = {
 
 module.exports = {
     name     : 'Statistics',
-    methods : [
+    endpoints : [
         {
             name     : 'Get contributors list with additions, deletions, and commit counts',
             synopsis : '',

--- a/application/config/github/repositories/statuses.js
+++ b/application/config/github/repositories/statuses.js
@@ -17,7 +17,7 @@ var paramRepo = {
 };
 
 module.exports = {
-    name     : 'Statuses',
+    name      : 'Statuses',
     endpoints : [
         {
             name     : 'Create a Status',

--- a/application/config/github/repositories/statuses.js
+++ b/application/config/github/repositories/statuses.js
@@ -18,7 +18,7 @@ var paramRepo = {
 
 module.exports = {
     name     : 'Statuses',
-    methods : [
+    endpoints : [
         {
             name     : 'Create a Status',
             synopsis : '',

--- a/application/config/github/search.js
+++ b/application/config/github/search.js
@@ -30,7 +30,7 @@ var paramOrder = {
 };
 
 module.exports = {
-    name     : 'Search',
+    name      : 'Search',
     endpoints : [
         {
             name     : 'Search repositories',

--- a/application/config/github/search.js
+++ b/application/config/github/search.js
@@ -31,7 +31,7 @@ var paramOrder = {
 
 module.exports = {
     name     : 'Search',
-    methods : [
+    endpoints : [
         {
             name     : 'Search repositories',
             synopsis : 'Find repositories via various criteria. This method returns up to 100 results per page.',

--- a/application/config/github/users.js
+++ b/application/config/github/users.js
@@ -1,7 +1,7 @@
 'use strict';
 
 module.exports = {
-    name     : 'Users',
+    name      : 'Users',
     endpoints : [
         {
             name     : 'Get a single user',

--- a/application/config/github/users.js
+++ b/application/config/github/users.js
@@ -2,7 +2,7 @@
 
 module.exports = {
     name     : 'Users',
-    methods : [
+    endpoints : [
         {
             name     : 'Get a single user',
             synopsis : '',

--- a/application/config/github/users/emails.js
+++ b/application/config/github/users/emails.js
@@ -9,7 +9,7 @@ var paramEmails = {
 };
 
 module.exports = {
-    name     : 'Emails',
+    name      : 'Emails',
     endpoints : [
         {
             name     : 'List email addresses for a user',

--- a/application/config/github/users/emails.js
+++ b/application/config/github/users/emails.js
@@ -10,7 +10,7 @@ var paramEmails = {
 
 module.exports = {
     name     : 'Emails',
-    methods : [
+    endpoints : [
         {
             name     : 'List email addresses for a user',
             synopsis : '',

--- a/application/config/github/users/followers.js
+++ b/application/config/github/users/followers.js
@@ -9,7 +9,7 @@ var paramUsername = {
 };
 
 module.exports = {
-    name     : 'Followers',
+    name      : 'Followers',
     endpoints : [
         {
             name     : 'List a user’s followers',

--- a/application/config/github/users/followers.js
+++ b/application/config/github/users/followers.js
@@ -10,7 +10,7 @@ var paramUsername = {
 
 module.exports = {
     name     : 'Followers',
-    methods : [
+    endpoints : [
         {
             name     : 'List a user’s followers',
             synopsis : '',

--- a/application/config/github/users/public_keys.js
+++ b/application/config/github/users/public_keys.js
@@ -17,7 +17,7 @@ var paramUsername = {
 };
 
 module.exports = {
-    name     : 'Public Keys',
+    name      : 'Public Keys',
     endpoints : [
         {
             name     : 'List public keys for a user',

--- a/application/config/github/users/public_keys.js
+++ b/application/config/github/users/public_keys.js
@@ -18,7 +18,7 @@ var paramUsername = {
 
 module.exports = {
     name     : 'Public Keys',
-    methods : [
+    endpoints : [
         {
             name     : 'List public keys for a user',
             synopsis : 'Lists the verified public keys for a user. This is accessible by anyone.',


### PR DESCRIPTION
## Update lively config files to match Github API

### Acceptance Criteria
1. The lively config files match the current Github API at https://developer.github.com/v3/
1. Endpoints work as expected.
1. No broken links

### Additional Details
The [Users/Administration (Enterprise) section](https://developer.github.com/v3/users/administration/) and all of the [Enterprise 2.1 section](https://developer.github.com/v3/enterprise/) are being left out for now.
