### PR TITLE
Copy Response to Clipboard link

### DIFF
--- a/application/ui/components/api-call-info.jsx
+++ b/application/ui/components/api-call-info.jsx
@@ -1,11 +1,12 @@
 /** @jsx React.DOM */
 'use strict';
 
-var _        = require('underscore');
-var React    = require('react');
-var cx       = require('react/lib/cx');
-var marked   = require('marked');
-var renderer = new marked.Renderer();
+var _             = require('underscore');
+var React         = require('react');
+var cx            = require('react/lib/cx');
+var marked        = require('marked');
+var renderer      = new marked.Renderer();
+var highlightText = require('../../util/highlight-text');
 
 renderer.paragraph = function(text) {
     return text;
@@ -38,6 +39,14 @@ module.exports = React.createClass({
         } catch (e) {
             return text;
         }
+    },
+
+    /**
+     * Highlight the response body for easy copying
+     */
+    highlightBody : function()
+    {
+        highlightText(this.refs.responseBody.getDOMNode());
     },
 
     render : function()
@@ -85,8 +94,17 @@ module.exports = React.createClass({
                     <h3 className='data__header'>Response Headers</h3>
                     <pre><code className={successClasses}>{this.props.response.headers}</code></pre>
 
-                    <h3 className='data__header'>Response Body</h3>
-                    <pre><code className={successClasses}>{this.formatResponse(this.props.response.data)}</code></pre>
+                    <h3 className='data__header'>
+                        {'Response Body '}
+                        <a onClick={this.highlightBody}>
+                            <span className={'fa fa-clipboard'} />
+                        </a>
+                    </h3>
+                    <pre>
+                        <code className={successClasses} ref={'responseBody'}>
+                            {this.formatResponse(this.props.response.data)}
+                        </code>
+                    </pre>
                 </div>
             );
         }

--- a/application/util/highlight-text.js
+++ b/application/util/highlight-text.js
@@ -1,0 +1,18 @@
+/* global window, document */
+'use strict';
+
+/**
+ * Highlight the text in the given DOM node
+ *
+ * @param  {DOM Element} domNode The DOM Element whose text to highlight
+ */
+module.exports = function (domNode) {
+    var range, selection;
+
+    selection = window.getSelection();
+    range     = document.createRange();
+
+    range.selectNodeContents(domNode);
+    selection.removeAllRanges();
+    selection.addRange(range);
+};


### PR DESCRIPTION
## As a user, when a response is returned I can ~~copy~~ highlight the response body into my clipboard with a link, so that I don't have to manually select it.

### Acceptance Criteria
1. User can click on a "Highlight" link (looks like a clipboard icon) next to the response body header and the response body is highlighted.
1. This works in Chrome. (Don't block this issue if it doesn't work in other browsers, but please leave notes about what browsers it does and doesn't work in.)

### Tasks
- Make link. Wire it up.

### Additional Notes
- Turns out there's not a way with straight JavaScript to copy text to the clipboard. [GitHub uses a flash library called ZeroClipboard](https://github.com/blog/1365-a-more-transparent-clipboard-button).
- [window.getSelection](https://developer.mozilla.org/en-US/docs/Web/API/Window.getSelection)
- [Some example I didn't end up using](http://stackoverflow.com/a/1173319).
- [Another example](http://stackoverflow.com/a/987376) -- I used the Mozilla conditional block. Works for Chrome.