### PR TITLE
Update lively config files to match Github API for endpoints with custom accept headers

### DIFF
--- a/application/config/github/activity/starring.js
+++ b/application/config/github/activity/starring.js
@@ -88,6 +88,26 @@ module.exports = {
             ]
         },
         {
+            name     : 'List repositories being starred with star creation timestamps.',
+            synopsis : '',
+            method   : 'GET',
+            uri      : '/users/:username/starred',
+            oauth    : false,
+            params   : [
+                paramUsername,
+                paramSort,
+                paramDirection,
+                {
+                    name        : 'Accept',
+                    required    : false,
+                    description : 'Include this header with the given value to get star creation timestamps',
+                    location    : 'header',
+                    type        : 'enum',
+                    enumValues  : ['application/vnd.github.v3.star+json']
+                }
+            ]
+        },
+        {
             name     : 'Check if you are starring a repository',
             synopsis : 'Requires for the user to be authenticated.',
             method   : 'GET',

--- a/application/config/github/organizations.js
+++ b/application/config/github/organizations.js
@@ -114,6 +114,7 @@ module.exports = {
     ],
     resources : [
         require('./organizations/members'),
-        require('./organizations/teams')
+        require('./organizations/teams'),
+        require('./organizations/webhooks')
     ]
 };

--- a/application/config/github/organizations/members.js
+++ b/application/config/github/organizations/members.js
@@ -109,6 +109,74 @@ module.exports = {
             ]
         },
         {
+            name     : 'Get organization membership',
+            synopsis : 'In order to get a user’s membership with an organization, the authenticated user must be an organization admin.',
+            method   : 'GET',
+            uri      : '/orgs/:org/memberships/:user',
+            oauth    : true,
+            params   : [
+                paramOrg,
+                paramUser,
+                {
+                    name        : 'Accept',
+                    required    : false,
+                    description : 'This endpoint is currently in a migration period allowing applications to opt in to the Organization Permissions API. To access this API method during the migration period, you must provide a custom media type in the Accept header.',
+                    location    : 'header',
+                    type        : 'enum',
+                    enumValues  : ['application/vnd.github.moondragon+json']
+                }
+            ]
+        },
+        {
+            name     : 'Add or update organization membership',
+            synopsis : 'In order to create or update a user’s membership with an organization, the authenticated user must be an organization admin.',
+            method   : 'PUT',
+            uri      : '/orgs/:org/memberships/:user',
+            oauth    : true,
+            params   : [
+                paramOrg,
+                paramUser,
+                {
+                    name        : 'role',
+                    required    : true,
+                    description : 'The role to give the user in the organization. Can be one of: admin - The user will become an administrator of the organization. member - The user will become a non-admin member of the organization. Use this only to demote an existing admin to a non-admin.',
+                    location    : 'body',
+                    type        : 'enum',
+                    enumValues  : [
+                        'admin',
+                        'member'
+                    ]
+                },
+                {
+                    name        : 'Accept',
+                    required    : false,
+                    description : 'This endpoint is currently in a migration period allowing applications to opt in to the Organization Permissions API. To access this API method during the migration period, you must provide a custom media type in the Accept header.',
+                    location    : 'header',
+                    type        : 'enum',
+                    enumValues  : ['application/vnd.github.moondragon+json']
+                }
+            ]
+        },
+        {
+            name     : 'Remove organization membership',
+            synopsis : 'In order to remove a user’s membership with an organization, the authenticated user must be an organization admin.',
+            method   : 'DELETE',
+            uri      : '/orgs/:org/memberships/:user',
+            oauth    : true,
+            params   : [
+                paramOrg,
+                paramUser,
+                {
+                    name        : 'Accept',
+                    required    : false,
+                    description : 'This endpoint is currently in a migration period allowing applications to opt in to the Organization Permissions API. To access this API method during the migration period, you must provide a custom media type in the Accept header.',
+                    location    : 'header',
+                    type        : 'enum',
+                    enumValues  : ['application/vnd.github.moondragon+json']
+                }
+            ]
+        },
+        {
             name     : 'List your organization memberships',
             synopsis : '',
             method   : 'GET',

--- a/application/config/github/organizations/webhooks.js
+++ b/application/config/github/organizations/webhooks.js
@@ -1,0 +1,225 @@
+'use strict';
+
+var acceptHeader = {
+    name        : 'Accept',
+    required    : false,
+    description : 'This endpoint is currently in a migration period allowing applications to opt in to the Organization Webhooks API. To access this API method during the migration period, you must provide a custom media type in the Accept header.',
+    location    : 'header',
+    type        : 'enum',
+    enumValues  : ['application/vnd.github.sersi-preview+json']
+};
+
+var paramOrg = {
+    name         : 'org',
+    required     : true,
+    type         : 'string',
+    location     : 'uri',
+    description  : 'The name of the organization.'
+};
+
+var paramId = {
+    name         : 'id',
+    required     : true,
+    type         : 'string',
+    location     : 'uri',
+    description  : 'The id of the webhook.'
+};
+
+module.exports = {
+    name      : 'Webhooks',
+    synopsis  : 'Organization webhooks allow you to receive HTTP POST payloads whenever certain events happen within the organization. Subscribing to these events makes it possible to build integrations that react to actions on GitHub.com.',
+    endpoints : [
+        {
+            name     : 'List hooks',
+            synopsis : '',
+            method   : 'GET',
+            uri      : '/orgs/:org/hooks',
+            oauth    : true,
+            params   : [
+                acceptHeader,
+                paramOrg
+            ]
+        },
+        {
+            name     : 'Get single hook',
+            synopsis : '',
+            method   : 'GET',
+            uri      : '/orgs/:org/hooks/:id',
+            oauth    : true,
+            params   : [
+                acceptHeader,
+                paramOrg,
+                paramId
+            ]
+        },
+        {
+            name     : 'Create a hook',
+            synopsis : '',
+            method   : 'POST',
+            uri      : '/orgs/:org/hooks',
+            oauth    : true,
+            params   : [
+                acceptHeader,
+                paramOrg,
+                {
+                    name        : 'name',
+                    required    : true,
+                    description : 'Must be passed as “web”.',
+                    location    : 'body',
+                    type        : 'enum',
+                    enumValues  : [
+                        'web'
+                    ]
+                },
+                {
+                    name        : 'config',
+                    required    : true,
+                    description : 'Key/value pairs to provide settings for this webhook.',
+                    location    : 'body',
+                    type        : 'hash',
+                    params      : [
+                        {
+                            name        : 'url',
+                            type        : 'string',
+                            required    : true,
+                            location    : 'body',
+                            description : 'The URL to which the payloads will be delivered.'
+                        },
+                        {
+                            name         : 'content_type',
+                            type         : 'enum',
+                            required     : false,
+                            location     : 'body',
+                            defaultValue : 'form',
+                            description  : 'The media type used to serialize the payloads.',
+                            enumValues   : [
+                                'form',
+                                'json'
+                            ]
+                        },
+                        {
+                            name        : 'secret',
+                            type        : 'string',
+                            required    : false,
+                            location    : 'body',
+                            description : 'If provided, payloads will be delivered with an X-Hub-Signature header. The value of this header is computed as the HMAC hex digest of the body, using the secret as the key.'
+                        },
+                        {
+                            name        : 'insecure_ssl',
+                            type        : 'string',
+                            required    : false,
+                            location    : 'body',
+                            description : 'Determines whether the SSL certificate of the host for url will be verified when delivering payloads. Supported values include "0" (verification is performed) and "1" (verification is not performed). The default is "0". We strongly recommend not setting this to “1” as you are subject to man-in-the-middle and other attacks.'
+                        },
+                    ]
+                },
+                {
+                    name         : 'events',
+                    required     : false,
+                    description  : 'Determines what events the hook is triggered for.',
+                    location     : 'body',
+                    type         : 'array[string]'
+                },
+                {
+                    name         : 'active',
+                    required     : false,
+                    description  : 'Determines whether the hook is actually triggered on pushes.',
+                    location     : 'body',
+                    type         : 'boolean'
+                }
+            ]
+        },
+        {
+            name     : 'Edit a hook',
+            synopsis : '',
+            method   : 'PATCH',
+            uri      : '/orgs/:org/hooks/:id',
+            oauth    : true,
+            params   : [
+                acceptHeader,
+                paramOrg,
+                paramId,
+                {
+                    name        : 'config',
+                    required    : true,
+                    description : 'Key/value pairs to provide settings for this webhook.',
+                    location    : 'body',
+                    type        : 'hash',
+                    params      : [
+                        {
+                            name        : 'url',
+                            type        : 'string',
+                            required    : true,
+                            location    : 'body',
+                            description : 'The URL to which the payloads will be delivered.'
+                        },
+                        {
+                            name         : 'content_type',
+                            type         : 'enum',
+                            required     : false,
+                            location     : 'body',
+                            defaultValue : 'form',
+                            description  : 'The media type used to serialize the payloads.',
+                            enumValues   : [
+                                'form',
+                                'json'
+                            ]
+                        },
+                        {
+                            name        : 'secret',
+                            type        : 'string',
+                            required    : false,
+                            location    : 'body',
+                            description : 'If provided, payloads will be delivered with an X-Hub-Signature header. The value of this header is computed as the HMAC hex digest of the body, using the secret as the key.'
+                        },
+                        {
+                            name        : 'insecure_ssl',
+                            type        : 'string',
+                            required    : false,
+                            location    : 'body',
+                            description : 'Determines whether the SSL certificate of the host for url will be verified when delivering payloads. Supported values include "0" (verification is performed) and "1" (verification is not performed). The default is "0". We strongly recommend not setting this to “1” as you are subject to man-in-the-middle and other attacks.'
+                        },
+                    ]
+                },
+                {
+                    name         : 'events',
+                    required     : false,
+                    description  : 'Determines what events the hook is triggered for.',
+                    location     : 'body',
+                    type         : 'array[string]'
+                },
+                {
+                    name         : 'active',
+                    required     : false,
+                    description  : 'Determines whether the hook is actually triggered on pushes.',
+                    location     : 'body',
+                    type         : 'boolean'
+                }
+            ]
+        },
+        {
+            name     : 'Ping a hook',
+            synopsis : 'This will trigger a ping event to be sent to the hook.',
+            method   : 'POST',
+            uri      : '/orgs/:org/hooks/:id/pings',
+            oauth    : true,
+            params   : [
+                acceptHeader,
+                paramOrg,
+                paramId
+            ]
+        },
+        {
+            name     : 'Delete a hook',
+            synopsis : '',
+            method   : 'DELETE',
+            uri      : '/orgs/:org/hooks/:id',
+            oauth    : true,
+            params   : [
+                acceptHeader,
+                paramOrg,
+                paramId
+            ]
+        }
+    ]
+};


### PR DESCRIPTION
## Update lively config files to match Github API for endpoints with custom accept headers
On #114, I didn't figure out that the Accept header could be overwritten by using a parameter in the lively configs. 

### Acceptance Criteria
1. The following endpoints are added to the lively configs. 
 1. Starring - List repositories being starred with star creation timestamps
 1. Get organization membership
 1. Add or update organization membership
 1. Remove organization membership
 1. All endpoints under Organizations/Webhooks

### Additional Notes
QA - It looks like you can create a free organization to test the org members / webhooks endpoints https://github.com/organizations/new
https://developer.github.com/v3/