### PR TITLE
Allow sending specific param as the body instead of an object

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,8 @@ An API is made up of multiple resources. Each resource has a list of endpoints t
     method   : 'GET',
     uri      : '/repos/:owner/:repo/events',
     oauth    : false,
+    bodyType : 'json-object',
+    bodyParam: null,
     params   : [
         {
             name        : 'owner',
@@ -143,6 +145,8 @@ An API is made up of multiple resources. Each resource has a list of endpoints t
 - **method**: A `string` containing the HTTP method to be used for the request.
 - **uri**: A `string` containing the path of the endpoint. Parts that are prefixed with `:` will be filled in by the `param` with the same name and its `location` set to `uri`. See below for more details on `params`.
 - **oauth**: A `bool` (`true` or `false`) which determines whether or not this request defaults to using oauth or unauthenticated.
+- **bodyType**: A `string` containing the body type the request should contain.  Default is `json-object`, only alternate at this time is `json-param`, which will use the contents of a specific `param` to be the body of the request.
+- **bodyParam**: A `string` containing the specific `params` name to use as the request body.  Only applies when `bodyType` is set to `json-param`, otherwise it is optional.
 - **params**: An array of `Object` containing parameter objects which this endpoint can accept. See below for details.
 
 ### Param Configuration

--- a/README.md
+++ b/README.md
@@ -126,7 +126,6 @@ An API is made up of multiple resources. Each resource has a list of endpoints t
     uri      : '/repos/:owner/:repo/events',
     oauth    : false,
     bodyType : 'json-object',
-    bodyParam: null,
     params   : [
         {
             name        : 'owner',
@@ -145,8 +144,7 @@ An API is made up of multiple resources. Each resource has a list of endpoints t
 - **method**: A `string` containing the HTTP method to be used for the request.
 - **uri**: A `string` containing the path of the endpoint. Parts that are prefixed with `:` will be filled in by the `param` with the same name and its `location` set to `uri`. See below for more details on `params`.
 - **oauth**: A `bool` (`true` or `false`) which determines whether or not this request defaults to using oauth or unauthenticated.
-- **bodyType**: A `string` containing the body type the request should contain.  Default is `json-object`, only alternate at this time is `json-param`, which will use the contents of a specific `param` to be the body of the request.
-- **bodyParam**: A `string` containing the specific `params` name to use as the request body.  Only applies when `bodyType` is set to `json-param`, otherwise it is optional.
+- **bodyType**: A `string` containing the body type the request should contain.  Default is `json-object`, only alternate at this time is `json-param`, which will use the contents of the remaining body `param` as the request body.
 - **params**: An array of `Object` containing parameter objects which this endpoint can accept. See below for details.
 
 ### Param Configuration

--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ An API is made up of multiple resources. Each resource has a list of endpoints t
 - **uri**: A `string` containing the path of the endpoint. Parts that are prefixed with `:` will be filled in by the `param` with the same name and its `location` set to `uri`. See below for more details on `params`.
 - **oauth**: A `bool` (`true` or `false`) which determines whether or not this request defaults to using oauth or unauthenticated.
 - **bodyType**: A `string` containing the body type the request should contain.  Default is `json-object`, only alternate at this time is `json-param`, which will use the contents of the remaining body `param` as the request body.
+- **rootParam**: A `string` containing the name of the parameter which will be used as the body request.  This option is only available when `bodyType = 'json-param'`.
 - **params**: An array of `Object` containing parameter objects which this endpoint can accept. See below for details.
 
 ### Param Configuration

--- a/application/action/request.js
+++ b/application/action/request.js
@@ -40,7 +40,7 @@ module.exports = {
 
         client = new Client(apiName);
 
-        if (bodyType == 'json-param') {
+        if (bodyType === 'json-param') {
             bodyParams = bodyParams[Object.keys(bodyParams)[0]];
         }
 

--- a/application/action/request.js
+++ b/application/action/request.js
@@ -34,11 +34,15 @@ module.exports = {
         });
     },
 
-    request : function(apiName, endpointName, method, path, queryParams, bodyParams, headers)
+    request : function(apiName, endpointName, method, path, queryParams, bodyParams, headers, bodyType, bodyParam)
     {
         var client, flux = this;
 
         client = new Client(apiName);
+
+        if (bodyType == 'json-param') {
+            bodyParams = bodyParams[bodyParam];
+        }
 
         client.request(method, path, queryParams, bodyParams, headers)
             .then(

--- a/application/action/request.js
+++ b/application/action/request.js
@@ -5,7 +5,7 @@ var Client    = require('../client');
 
 module.exports = {
 
-    oauthRequest : function(apiName, endpointName, accessToken, method, path, queryParams, bodyParams, headers, bodyType)
+    oauthRequest : function(apiName, endpointName, accessToken, method, path, queryParams, bodyParams, headers, bodyType, rootParam)
     {
         var client, flux = this;
 
@@ -16,7 +16,7 @@ module.exports = {
         client = new Client(apiName);
 
         if (bodyType === 'json-param') {
-            bodyParams = bodyParams[Object.keys(bodyParams)[0]];
+            bodyParams = bodyParams[rootParam];
         }
 
         client.authRequest(accessToken, method, path, queryParams, bodyParams, headers)
@@ -38,14 +38,14 @@ module.exports = {
         });
     },
 
-    request : function(apiName, endpointName, method, path, queryParams, bodyParams, headers, bodyType)
+    request : function(apiName, endpointName, method, path, queryParams, bodyParams, headers, bodyType, rootParam)
     {
         var client, flux = this;
 
         client = new Client(apiName);
 
         if (bodyType === 'json-param') {
-            bodyParams = bodyParams[Object.keys(bodyParams)[0]];
+            bodyParams = bodyParams[rootParam];
         }
 
         client.request(method, path, queryParams, bodyParams, headers)

--- a/application/action/request.js
+++ b/application/action/request.js
@@ -5,7 +5,7 @@ var Client    = require('../client');
 
 module.exports = {
 
-    oauthRequest : function(apiName, endpointName, accessToken, method, path, queryParams, bodyParams, headers)
+    oauthRequest : function(apiName, endpointName, accessToken, method, path, queryParams, bodyParams, headers, bodyType)
     {
         var client, flux = this;
 
@@ -14,6 +14,10 @@ module.exports = {
         }
 
         client = new Client(apiName);
+
+        if (bodyType === 'json-param') {
+            bodyParams = bodyParams[Object.keys(bodyParams)[0]];
+        }
 
         client.authRequest(accessToken, method, path, queryParams, bodyParams, headers)
             .then(

--- a/application/action/request.js
+++ b/application/action/request.js
@@ -34,14 +34,14 @@ module.exports = {
         });
     },
 
-    request : function(apiName, endpointName, method, path, queryParams, bodyParams, headers, bodyType, bodyParam)
+    request : function(apiName, endpointName, method, path, queryParams, bodyParams, headers, bodyType)
     {
         var client, flux = this;
 
         client = new Client(apiName);
 
         if (bodyType == 'json-param') {
-            bodyParams = bodyParams[bodyParam];
+            bodyParams = bodyParams[Object.keys(bodyParams)[0]];
         }
 
         client.request(method, path, queryParams, bodyParams, headers)

--- a/application/config/github/users/emails.js
+++ b/application/config/github/users/emails.js
@@ -26,6 +26,7 @@ module.exports = {
             uri      : '/user/emails',
             oauth    : true,
             bodyType : 'json-param',
+            rootParam: 'emails',
             params   : [
                 paramEmails
             ]
@@ -37,6 +38,7 @@ module.exports = {
             uri      : '/user/emails',
             oauth    : true,
             bodyType : 'json-param',
+            rootParam: 'emails',
             params   : [
                 paramEmails
             ]

--- a/application/config/github/users/emails.js
+++ b/application/config/github/users/emails.js
@@ -25,6 +25,8 @@ module.exports = {
             method   : 'POST',
             uri      : '/user/emails',
             oauth    : true,
+            bodyType : 'json-param',
+            bodyParam: 'emails',
             params   : [
                 paramEmails
             ]
@@ -35,6 +37,8 @@ module.exports = {
             method   : 'DELETE',
             uri      : '/user/emails',
             oauth    : true,
+            bodyType : 'json-param',
+            bodyParam: 'emails',
             params   : [
                 paramEmails
             ]

--- a/application/config/github/users/emails.js
+++ b/application/config/github/users/emails.js
@@ -26,7 +26,6 @@ module.exports = {
             uri      : '/user/emails',
             oauth    : true,
             bodyType : 'json-param',
-            bodyParam: 'emails',
             params   : [
                 paramEmails
             ]
@@ -38,7 +37,6 @@ module.exports = {
             uri      : '/user/emails',
             oauth    : true,
             bodyType : 'json-param',
-            bodyParam: 'emails',
             params   : [
                 paramEmails
             ]

--- a/application/ui/components/endpoint.jsx
+++ b/application/ui/components/endpoint.jsx
@@ -25,6 +25,8 @@ module.exports = React.createClass({
         name     : React.PropTypes.string.isRequired,
         synopsis : React.PropTypes.string,
         method   : React.PropTypes.oneOf(['GET', 'HEAD', 'POST', 'PUT', 'DELETE', 'PATCH']),
+        bodyType : React.PropTypes.string,
+        bodyParam: React.PropTypes.string,
         uri      : React.PropTypes.string.isRequired,
         oauth    : React.PropTypes.bool,
         params   : React.PropTypes.array
@@ -112,9 +114,11 @@ module.exports = React.createClass({
 
     onSubmit : function()
     {
-        var values = this.state.values,
-            method = this.props.method,
-            uri    = this.props.uri,
+        var values      = this.state.values,
+            method      = this.props.method,
+            uri         = this.props.uri,
+            bodyType    = this.props.bodyType,
+            bodyParam   = this.props.bodyParam,
             accessToken = this.getFlux().store('OAuthStore').getState().accessToken;
 
         var headerParams = {},
@@ -156,6 +160,11 @@ module.exports = React.createClass({
             }
 
             var paramData = _.findWhere(this.props.params, { name : name });
+            bodyType  = this.props.bodyType;
+            bodyParam = false;
+            if (bodyType == 'json-param') {
+                bodyParam = this.props.bodyParam;
+            }
 
             if (paramData.type === 'file') {
                 bodyParams = value;
@@ -192,7 +201,9 @@ module.exports = React.createClass({
                 uri,
                 queryParams,
                 bodyParams,
-                headerParams
+                headerParams,
+                bodyType,
+                bodyParam
             );
         }
 
@@ -372,6 +383,5 @@ module.exports = React.createClass({
                 </div>
             </div>
         );
-
     }
 });

--- a/application/ui/components/endpoint.jsx
+++ b/application/ui/components/endpoint.jsx
@@ -26,7 +26,6 @@ module.exports = React.createClass({
         synopsis : React.PropTypes.string,
         method   : React.PropTypes.oneOf(['GET', 'HEAD', 'POST', 'PUT', 'DELETE', 'PATCH']),
         bodyType : React.PropTypes.string,
-        bodyParam: React.PropTypes.string,
         uri      : React.PropTypes.string.isRequired,
         oauth    : React.PropTypes.bool,
         params   : React.PropTypes.array
@@ -118,7 +117,6 @@ module.exports = React.createClass({
             method      = this.props.method,
             uri         = this.props.uri,
             bodyType    = this.props.bodyType,
-            bodyParam   = this.props.bodyParam,
             accessToken = this.getFlux().store('OAuthStore').getState().accessToken;
 
         var headerParams = {},
@@ -161,10 +159,6 @@ module.exports = React.createClass({
 
             var paramData = _.findWhere(this.props.params, { name : name });
             bodyType  = this.props.bodyType;
-            bodyParam = false;
-            if (bodyType == 'json-param') {
-                bodyParam = this.props.bodyParam;
-            }
 
             if (paramData.type === 'file') {
                 bodyParams = value;
@@ -202,8 +196,7 @@ module.exports = React.createClass({
                 queryParams,
                 bodyParams,
                 headerParams,
-                bodyType,
-                bodyParam
+                bodyType
             );
         }
 

--- a/application/ui/components/endpoint.jsx
+++ b/application/ui/components/endpoint.jsx
@@ -185,7 +185,8 @@ module.exports = React.createClass({
                 uri,
                 queryParams,
                 bodyParams,
-                headerParams
+                headerParams,
+                bodyType
             );
         } else {
             this.getFlux().actions.request.request(

--- a/application/ui/components/endpoint.jsx
+++ b/application/ui/components/endpoint.jsx
@@ -26,6 +26,7 @@ module.exports = React.createClass({
         synopsis : React.PropTypes.string,
         method   : React.PropTypes.oneOf(['GET', 'HEAD', 'POST', 'PUT', 'DELETE', 'PATCH']),
         bodyType : React.PropTypes.string,
+        rootParam: React.PropTypes.string,
         uri      : React.PropTypes.string.isRequired,
         oauth    : React.PropTypes.bool,
         params   : React.PropTypes.array
@@ -117,6 +118,7 @@ module.exports = React.createClass({
             method      = this.props.method,
             uri         = this.props.uri,
             bodyType    = this.props.bodyType,
+            rootParam   = this.props.rootParam,
             accessToken = this.getFlux().store('OAuthStore').getState().accessToken;
 
         var headerParams = {},
@@ -186,7 +188,8 @@ module.exports = React.createClass({
                 queryParams,
                 bodyParams,
                 headerParams,
-                bodyType
+                bodyType,
+                rootParam
             );
         } else {
             this.getFlux().actions.request.request(
@@ -197,7 +200,8 @@ module.exports = React.createClass({
                 queryParams,
                 bodyParams,
                 headerParams,
-                bodyType
+                bodyType,
+                rootParam
             );
         }
 

--- a/application/ui/components/resource.jsx
+++ b/application/ui/components/resource.jsx
@@ -85,7 +85,6 @@ module.exports = React.createClass({
                oauth               = {endpoint.oauth}
                params              = {endpoint.params}
                bodyType            = {endpoint.bodyType ? endpoint.bodyType : 'json-object'}
-               bodyParam           = {endpoint.bodyParam ? endpoint.bodyParam : null}
                endpointPanelHidden = {! this.state.expanded[id]}
                toggleEndpointPanel = {_.partial(this.toggleDisplayEndpoint, id)}
             />

--- a/application/ui/components/resource.jsx
+++ b/application/ui/components/resource.jsx
@@ -85,6 +85,7 @@ module.exports = React.createClass({
                oauth               = {endpoint.oauth}
                params              = {endpoint.params}
                bodyType            = {endpoint.bodyType ? endpoint.bodyType : 'json-object'}
+               rootParam           = {endpoint.rootParam}
                endpointPanelHidden = {! this.state.expanded[id]}
                toggleEndpointPanel = {_.partial(this.toggleDisplayEndpoint, id)}
             />

--- a/application/ui/components/resource.jsx
+++ b/application/ui/components/resource.jsx
@@ -84,6 +84,8 @@ module.exports = React.createClass({
                uri                 = {endpoint.uri}
                oauth               = {endpoint.oauth}
                params              = {endpoint.params}
+               bodyType            = {endpoint.bodyType ? endpoint.bodyType : 'json-object'}
+               bodyParam           = {endpoint.bodyParam ? endpoint.bodyParam : null}
                endpointPanelHidden = {! this.state.expanded[id]}
                toggleEndpointPanel = {_.partial(this.toggleDisplayEndpoint, id)}
             />


### PR DESCRIPTION
## Description
To do this we need to allow specifying the body type and specify which parameter to use as the root.

## Acceptance Criteria
1. New body-type config for endpoints (default = json-object, json-param)
1. Executing request sends param as the request body

Note that going this route not only allows for arrays as the body, but also booleans, strings, etc. depending on the param type.

## Details

URL:  http://localhost:9001/github/emails

Receive a 500 error when entering in an additional email address.

```
{
    "message": "Server Error",
    "documentation_url": "https://developer.github.com/v3"
}
```

