### PR TITLE
Enum fields can have invalid defaultValues

### DIFF
--- a/application/ui/components/params-list.jsx
+++ b/application/ui/components/params-list.jsx
@@ -340,11 +340,19 @@ module.exports = React.createClass({
     {
         var changeHandler   = this.getChangeHandler(path, type),
             requestBodyCopy = _.extend({}, this.state.requestValues),
-            value           = NestedPropertyHandler.get(requestBodyCopy, path);
+            value           = NestedPropertyHandler.get(requestBodyCopy, path),
+            badConfig       = '';
 
         if (type === 'enum') {
             if (! options.enumValues.length) {
-                console.warn('Missing enumValues for param: ' + options.name);
+                badConfig = 'Missing Enum Values in api configuration';
+                console.warn('Missing Enum Values for param: ' + options.name);
+            } else if (
+                typeof options.defaultValue !== 'undefined'
+                && options.enumValues.indexOf(options.defaultValue) === -1
+            ) {
+                badConfig = 'Default value for enum not in values list';
+                console.warn('Defautl enum value not in values list');
             }
 
             return <Select value={value} key={key} options={options.enumValues} onChange={changeHandler} />;

--- a/application/ui/components/params-list.jsx
+++ b/application/ui/components/params-list.jsx
@@ -1,5 +1,4 @@
 /** @jsx React.DOM */
-/* global console */
 'use strict';
 
 var _                     = require('underscore');
@@ -339,21 +338,9 @@ module.exports = React.createClass({
     {
         var changeHandler   = this.getChangeHandler(path, type),
             requestBodyCopy = _.extend({}, this.state.requestValues),
-            value           = NestedPropertyHandler.get(requestBodyCopy, path),
-            badConfig       = '';
+            value           = NestedPropertyHandler.get(requestBodyCopy, path);
 
         if (type === 'enum') {
-            if (! options.enumValues.length) {
-                badConfig = 'Missing Enum Values in api configuration';
-                console.warn('Missing Enum Values for param: ' + options.name);
-            } else if (
-                typeof options.defaultValue !== 'undefined'
-                && options.enumValues.indexOf(options.defaultValue) === -1
-            ) {
-                badConfig = 'Default value for enum not in values list';
-                console.warn('Defautl enum value not in values list');
-            }
-
             return <Select value={value} key={key} options={options.enumValues} onChange={changeHandler} />;
         } else if (type === 'boolean') {
             return <Select value={value} key={key} options={['true', 'false']} onChange={changeHandler} />;

--- a/application/ui/components/params-list.jsx
+++ b/application/ui/components/params-list.jsx
@@ -12,7 +12,6 @@ var ParamHelper           = require('../../util/param-helper');
 var Select                = require('./input/select');
 var Text                  = require('./input/text');
 var ResumableUpload       = require('./input/resumable-upload');
-var NestedPropertyHandler = require('../../util/nested-property-handler');
 var UriHelperMixin        = require('../../util/uri-helper');
 
 module.exports = React.createClass({

--- a/application/ui/components/render-params-mixin.jsx
+++ b/application/ui/components/render-params-mixin.jsx
@@ -1,4 +1,5 @@
 /** @jsx React.DOM */
+/* global console */
 'use strict';
 
 var _           = require('underscore');
@@ -24,9 +25,32 @@ module.exports = {
         ];
     },
 
+    validateParamConfiguration : function(param)
+    {
+        var errors = [];
+
+        switch (param.type) {
+            case "enum":
+                if (! param.enumValues.length) {
+                    errors.push('Missing Enum Values');
+                } else if (
+                    typeof param.defaultValue !== 'undefined' &&
+                    param.enumValues.indexOf(param.defaultValue) === -1
+                ) {
+                    errors.push('Default value for enum not in values list');
+                }
+                break;
+        }
+
+        if (errors.length > 0) {
+            console.log(errors);
+        }
+        return errors;
+    },
+
     renderDescriptionColumn : function(param)
     {
-        var defaultValue, description, innerHtml;
+        var defaultValue, description, innerHtml, errors;
 
         if (_.isBoolean(param.defaultValue)) {
             defaultValue = (param.defaultValue) ? 'true' : 'false';
@@ -36,6 +60,15 @@ module.exports = {
 
         description = (param.required ? '**Required**. ' : '') + param.description
             + (defaultValue ? ' **Default:** ' + defaultValue : '');
+
+        // Add any configuration validation errors
+        errors = this.validateParamConfiguration(param);
+        if (errors.length > 0) {
+            description += "\n\n**API CONFIGURATION ERROR**\n";
+            for (var i in errors) {
+                description += "* " + errors[i] + "\n";
+            }
+        }
 
         innerHtml = {
             __html: marked(description)


### PR DESCRIPTION
## Description

If you make an `enum` field and give it a `defaultValue` that is not in `enumValues` and then send a request without touching the dropdown, Lively will send the `defaultValue` even thought it isn't a valid option.

Instead, it should throw a warning or an error or *something* saying, "hey -- this configuration is faulty".