### PR TITLE
Add Webpack Dev Server entry point to Webpack Config

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,7 +9,10 @@ var bowerPath   = path.resolve(__dirname, 'bower_components');
 var npmPath     = path.resolve(__dirname, 'node_modules');
 
 var config      = {
-    entry   : ['./application/bootstrap.js'],
+    entry   : [
+        'webpack/hot/dev-server',
+        './application/bootstrap.js'
+    ],
     plugins : [
         new ExtractTextPlugin('app.css', {allChunks : true}),
         new HtmlWebpack({template : './application/index.html'}),


### PR DESCRIPTION
## Add Webpack Dev Server entry point to Webpack Config, so that reloads happen.

Right now, running `node webpack` runs the Dev Server. However, this does not watch the application. This prevents the app from being rebundled whenever changes to an API config are made.

### Acceptance Criteria
1. When running `node webpack` from the Lively root directory, the app will rebundle new changes automatically when you change a source file or config.
 - If you're running Lively locally (just on `localhost:9001`) the changes should hot-reload, without needing a refresh. But if they don't, just refresh. That's not related to this issue. The only thing we care about is that changes cause a rebundle.

### Tasks
- Add new entry point is to webpack config: `webpack/hot/dev-server`

### Additional Notes
- To test this you should *not* run `npm start`.
- This missing entry point is documented [here](http://webpack.github.io/docs/webpack-dev-server.html) and [here](https://github.com/webpack/docs/wiki/hot-module-replacement-with-webpack).