### PR TITLE
Fix lively for hot loading on VM

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -32,7 +32,7 @@ var config      = {
 if (environment === 'development') {
     config.entry = [
         'webpack/hot/dev-server',
-        'webpack-dev-server/client?http://localhost:9001'
+        'webpack-dev-server/client?http://:9001'
     ].concat(config.entry);
 
     config.reactLoaders = ['react-hot'].concat(config.reactLoaders);


### PR DESCRIPTION
## Fix lively for hot loading on VM
### Acceptance Criteria
1. hot loader works on vm
### Tasks
- remove `localhost` from dev server config
### Additional Notes
- {{list additional notes here, remove if not applicable}}
