### PR TITLE
Enum not using first enumValue when no defaultValue is provided

### DIFF
--- a/application/ui/components/params.jsx
+++ b/application/ui/components/params.jsx
@@ -39,7 +39,7 @@ module.exports = React.createClass({
                     values[param.name] = param.defaultValue ? param.defaultValue : false;
                     break;
                 case 'enum':
-                    values[param.name] = param.defaultValue ? param.defaultValue : param.defaultValue;
+                    values[param.name] = param.defaultValue ? param.defaultValue : param.enumValues[0];
                     break;
                 case 'array':
                     values[param.name] = param.defaultValue ? param.defaultValue : [];


### PR DESCRIPTION
## Description

If no defaultValue is listed with an `enum` parameter, it ends up not included in the request body.

## Details

- Credentials: {{username / password (remove if not applicable)}}
- URL: {{url where problem occurs, remove if not applicable}}
- Note: {{relevant information like related issues, remove if not applicable}}
- Console Error: {{expand and copy from the console (include line error too), remove if not applicable}}