### PR TITLE
enum param inside array ending up with null value

### DIFF
--- a/application/ui/components/input/array.jsx
+++ b/application/ui/components/input/array.jsx
@@ -84,7 +84,7 @@ module.exports = React.createClass({
         var values = this.state.values;
 
         values.push(
-            null
+            typeof this.props.param.defaultValue !== 'undefined' ? this.props.param.defaultValue : null
         );
 
         this.setState({


### PR DESCRIPTION
## Description

When an array of enums (or probably any select-type param) is present, the values end up as null when adding them.  

To fix, check for defaultValue of the array's param property.

## Details

- Credentials: {{username / password (remove if not applicable)}}
- URL: {{url where problem occurs, remove if not applicable}}
- Note: {{relevant information like related issues, remove if not applicable}}
- Console Error: {{expand and copy from the console (include line error too), remove if not applicable}}