### PR TITLE
Unable to scroll longer response body

### DIFF
--- a/application/ui/scss/components/panel/_panel.scss
+++ b/application/ui/scss/components/panel/_panel.scss
@@ -193,7 +193,7 @@
 }
 
 .endpoint-panel {
-    max-height : 3000px;
+    max-height : 8000px;
     margin-top : 20px;
     transition : all 500ms ease-in-out;
 


### PR DESCRIPTION
## Description

When an endpoint has many parameters and the response body is longer the user is unable to see the entire response.  Should either allow the response body to be scrollable or to extend the endpoint container.

![long response scroll](https://cloud.githubusercontent.com/assets/999600/7073310/634c5246-dea7-11e4-8f38-1b14f6c02953.jpg)


