### PR TITLE
Error during `npm install`

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "markdown-loader"             : "0.1.2",
     "raw-loader"                  : "0.5.1",
     "react-hot-loader"            : "1.1.4",
-    "sass-loader"                 : "0.3.1",
+    "sass-loader"                 : "1.0.2",
     "style-loader"                : "0.8.3",
     "url-loader"                  : "0.5.5",
     "webpack"                     : "1.5.3",


### PR DESCRIPTION
https://github.com/sass/node-sass/issues/653

Summary: old versions of node-sass only work with node 0.10.x. The version of sass-loader we're using uses one of those old versions of node-sass.

# Acceptance Criteria
- `npm install` works
- `npm start` works
- The site works