### PR TITLE
Previous response still shown when "No access token provided" error shown

### DIFF
--- a/application/ui/components/endpoint.jsx
+++ b/application/ui/components/endpoint.jsx
@@ -122,13 +122,11 @@ module.exports = React.createClass({
             bodyParams   = {},
             queryParams  = {};
 
-        var buttonNode = this.refs.tryItButton.getDOMNode();
-
         if (this.refs.sendToken.getValue() === true && ! accessToken) {
             this.setState({
-                error : 'No access token provided.'
+                error  : 'No access token provided.',
+                loaded : false // Hides response if one is displayed
             });
-            window.scrollTo(0, window.scrollY + buttonNode.getBoundingClientRect().bottom);
             return;
         }
 


### PR DESCRIPTION
## Previous response still shown when "No access token provided" error shown

It even still scrolls down to it, making the error message hard to notice.

When this error occurs, the previous response should be removed.

## Steps to reproduce
1. Clear local storage so you don't have any access tokens stored
1. Pick an endpoint that requires authentication
1. Toggle the oauth switch to *not* include the token. This should result in an error response.
1. Toggle the oauth switch to include the token
1. Submit a request