### PR TITLE
Re-fix token refreshing

### DIFF
--- a/application/http/auth-gateway.js
+++ b/application/http/auth-gateway.js
@@ -40,6 +40,23 @@ var AuthGateway = ParentAuthGateway.extend({
             headers : responseHeaders,
             status  : response.statusCode
         });
+    },
+
+    handleTokenExchangeSuccess : function(token, method, path, data, headers, resolve, reject, response)
+    {
+        ParentAuthGateway.prototype.handleTokenExchangeSuccess.apply(
+            this,
+            [
+                token,
+                method,
+                path,
+                data,
+                headers,
+                resolve,
+                reject,
+                response.data
+            ]
+        );
     }
 });
 

--- a/package.json
+++ b/package.json
@@ -8,10 +8,10 @@
     "url"  : "https://github.com/synapsestudios/lively.git"
   },
   "scripts" : {
-    "start"   : "rm -rf ./build && webpack && node webpack",
+    "start"   : "rm -rf ./build && ./node_modules/webpack/bin/webpack.js && node webpack",
     "windows" : "rmdir /S /Q build && webpack.cmd && node webpack",
-    "webpack" : "rm -rf ./build && webpack",
-    "dist"    : "rm -rf ./build && APP_ENV=production webpack -p && zip -r build-`date +%s` application build node_modules server server.js",
+    "webpack" : "rm -rf ./build && ./node_modules/webpack/bin/webpack.js",
+    "dist"    : "rm -rf ./build && APP_ENV=production ./node_modules/webpack/bin/webpack.js -p && zip -r build-`date +%s` application build node_modules server server.js",
     "clean"   : "rm -rf ./build",
     "test"    : "jest"
   },

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "react-router"    : "0.12.4",
     "request"         : "2.39.0",
     "store"           : "1.3.16",
-    "synapse-common"  : "1.7.1",
+    "synapse-common"  : "1.8.1",
     "synfrastructure" : "1.0.0",
     "underscore"      : "1.6.0",
     "q"               : "1.1.2"


### PR DESCRIPTION
see https://github.com/synapsestudios/synapse-common/pull/52

## AC
- If making a request with an expired OAuth token, the console will show that the browser:
  - Initially makes request and receives 401
  - Makes request for refreshed token
  - After receiving updated token, remakes original request
- From lively, it will appear as if the request worked like normal.