### PR TITLE
Load HotModuleReplacementPlugin for qa environment

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -29,7 +29,7 @@ var config      = {
     )
 };
 
-if (environment === 'development') {
+if (environment === 'development' || environment === 'qa') {
     config.entry = [
         'webpack/hot/dev-server',
         'webpack-dev-server/client?http://localhost:9001'


### PR DESCRIPTION
## Load HotModuleReplacementPlugin for qa environments

### Acceptance Criteria
1. HotModuleReplacementPlugin is loaded if the environment is qa or development.

### Additional Notes
https://github.com/synapsestudios/lively/blob/develop/webpack.config.js#L32
