### PR TITLE
Update lively to use webpack 1.10.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "sass-loader"                 : "1.0.2",
     "style-loader"                : "0.8.3",
     "url-loader"                  : "0.5.5",
-    "webpack"                     : "1.5.3",
+    "webpack"                     : "1.10.0",
     "webpack-dev-server"          : "1.7.0",
     "webpack-error-notification"  : "0.1.4"
   },


### PR DESCRIPTION
## Update lively to use webpack 1.10.0

### Acceptance criteria
1. Lively builds

### Tasks
- update package.json with webpack 1.10.0
- ~~do do a hotfix to 0.4.0 and tag 0.4.1 (or just replace 0.4.0) so projects that are locked into older lively versions can build their lively~~

### Notes
Lively will fail to build on v0.4.0 (and possibly on the most recent release). Updating to webpack 1.10.0 allows lively to build without errors.

The error we get is:

```
/home/vagrant/lively/node_modules/webpack/lib/node/NodeWatchFileSystem.js:29
		throw new Error("Invalid arguments: 'delay'");
		      ^
Error: Invalid arguments: 'delay'
    at NodeWatchFileSystem.watch (/home/vagrant/lively/node_modules/webpack/lib/node/NodeWatchFileSystem.js:29:9)
    at Watching.watch (/home/vagrant/lively/node_modules/webpack/lib/Compiler.js:86:47)
    at Watching._done (/home/vagrant/lively/node_modules/webpack/lib/Compiler.js:82:8)
    at Watching.<anonymous> (/home/vagrant/lively/node_modules/webpack/lib/Compiler.js:60:18)
    at Tapable.emitRecords (/home/vagrant/lively/node_modules/webpack/lib/Compiler.js:277:37)
    at Watching.<anonymous> (/home/vagrant/lively/node_modules/webpack/lib/Compiler.js:57:19)
    at /home/vagrant/lively/node_modules/webpack/lib/Compiler.js:270:11
    at Tapable.applyPluginsAsync (/home/vagrant/lively/node_modules/webpack/node_modules/tapable/lib/Tapable.js:60:69)
    at Tapable.afterEmit (/home/vagrant/lively/node_modules/webpack/lib/Compiler.js:267:8)
    at Tapable.<anonymous> (/home/vagrant/lively/node_modules/webpack/lib/Compiler.js:262:14)
```