### PR TITLE
Allow configuration param to specify NOT to include the param by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [v1.0.6](https://github.com/synapsestudios/lively/compare/v1.0.2...v1.0.6) - ?
+### Fixed
+- [#155](https://github.com/synapsestudios/lively/pull/155) Allow default no-include for parameters.
+
 ## [v1.0.2](https://github.com/synapsestudios/lively/compare/v1.0.1...v1.0.2) - 2015-04-17
 ### Fixed
 - [#139](https://github.com/synapsestudios/lively/pull/139) Fixed enum param inside array ending up with null value.

--- a/README.md
+++ b/README.md
@@ -229,3 +229,4 @@ An API is made up of multiple resources. Each resource has a list of endpoints t
 - **location**: A `string` containing one of `header`, `body`, `uri` or `query`. If the param is named in the endpoint's URI, Lively will ignore the stated location. *Default:* `body` unless param is named in URI, then `uri`.
 - **defaultValue**: A `string`, `bool`, or `array` depending on what `type` is set. The default value to display in the param.
 - **description**: A `string` containing a short description of the parameter.
+- **include**: An optional boolean indicating if the parameter should NOT be included.  Will be included by default, but `false` will uncheck the include box.

--- a/application/config/github/repositories/statuses.js
+++ b/application/config/github/repositories/statuses.js
@@ -51,6 +51,7 @@ module.exports = {
                 {
                     name         : 'target_url',
                     required     : false,
+                    include      : false,
                     type         : 'string',
                     location     : 'body',
                     description  : 'The target URL to associate with this status. This URL will be linked from the GitHub UI to allow users to easily see the ‘source’ of the Status.'
@@ -58,6 +59,7 @@ module.exports = {
                 {
                     name         : 'description',
                     required     : false,
+                    include      : false,
                     type         : 'string',
                     location     : 'body',
                     description  : 'A short description of the status.'
@@ -65,6 +67,7 @@ module.exports = {
                 {
                     name         : 'context',
                     required     : false,
+                    include      : false,
                     defaultValue : 'default',
                     type         : 'string',
                     location     : 'body',

--- a/application/config/paramtest.js
+++ b/application/config/paramtest.js
@@ -93,6 +93,7 @@ var paramArrayCustom = {
 var paramStripe = {
     name        : 'stripeTokenKey',
     required    : false,
+    include     : false,
     type        : 'stripe-token',
     description : 'Not totally sure what this does but it works now.'
 };

--- a/application/ui/components/params.jsx
+++ b/application/ui/components/params.jsx
@@ -19,7 +19,9 @@ module.exports = React.createClass({
         var includes = {};
 
         _.each(this.props.params, function(param) {
-            includes[param.name] = true;
+            if (typeof param.include === 'undefined' || param.include !== false) {
+                includes[param.name] = true;
+            }
 
             if (typeof param.defaultValue !== 'undefined') {
                 values[param.name] = param.defaultValue;

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url"  : "https://github.com/synapsestudios/lively.git"
   },
   "scripts" : {
-    "start"   : "rm -rf ./build && webpack && node webpack",
+    "start"   : "node webpack",
     "windows" : "rmdir /S /Q build && webpack.cmd && node webpack",
     "webpack" : "rm -rf ./build && webpack",
     "dist"    : "rm -rf ./build && APP_ENV=production webpack -p && zip -r build-`date +%s` application build node_modules server server.js",


### PR DESCRIPTION
## Allow configuration param to specify NOT to include the param by default
param `include` will assume true unless specified false

### Acceptance Criteria
1. Params will be included by default
1. Params specified not to be included will not be in requests unless checked to be included

### Tasks
- {{list developer tasks here}}

### Additional Notes
- {{list additional notes here, remove if not applicable}}